### PR TITLE
fix(convert): emit stable-id change warnings via baseline compare

### DIFF
--- a/src/cli/convert.rs
+++ b/src/cli/convert.rs
@@ -1,7 +1,100 @@
+use std::collections::HashMap;
 use std::path::Path;
 
 use crate::ForgeError;
 use crate::cli::{OutputFormat, Strategy};
+use crate::model::{PolicyDocument, PolicySection};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+struct RequirementLocator {
+    section_path: String,
+    source_line: usize,
+    atom_index: usize,
+}
+
+fn collect_stable_ids(document: &PolicyDocument) -> HashMap<RequirementLocator, String> {
+    let mut map = HashMap::new();
+    for section in &document.sections {
+        collect_stable_ids_from_section(section, &section.title, &mut map);
+    }
+    map
+}
+
+fn collect_stable_ids_from_section(
+    section: &PolicySection,
+    section_path: &str,
+    map: &mut HashMap<RequirementLocator, String>,
+) {
+    for requirement in &section.requirements {
+        if let Some(stable_id) = &requirement.stable_id {
+            map.insert(
+                RequirementLocator {
+                    section_path: section_path.to_string(),
+                    source_line: requirement.source_line,
+                    atom_index: requirement.atom_index,
+                },
+                stable_id.clone(),
+            );
+        }
+    }
+
+    for child in &section.children {
+        let child_path = format!("{section_path}/{}", child.title);
+        collect_stable_ids_from_section(child, &child_path, map);
+    }
+}
+
+fn count_substantive_stable_id_changes(
+    current: &PolicyDocument,
+    baseline: &PolicyDocument,
+) -> usize {
+    let current_ids = collect_stable_ids(current);
+    let baseline_ids = collect_stable_ids(baseline);
+
+    current_ids
+        .iter()
+        .filter(|(locator, current_id)| {
+            baseline_ids.get(*locator).is_some_and(|baseline_id| baseline_id != *current_id)
+        })
+        .count()
+}
+
+fn validate_regular_file(path: &Path, flag_name: &str) -> Result<(), ForgeError> {
+    if !path.exists() {
+        return Err(ForgeError::Validation(format!(
+            "{flag_name} path '{}' does not exist (not found)",
+            path.display()
+        )));
+    }
+    if !path.is_file() {
+        return Err(ForgeError::Validation(format!(
+            "{flag_name} path '{}' is not a regular file (is a directory or special file)",
+            path.display()
+        )));
+    }
+    Ok(())
+}
+
+fn emit_stable_id_change_warning_if_needed(
+    input: &Path,
+    baseline: &Path,
+    max_size_bytes: u64,
+) -> Result<(), ForgeError> {
+    let baseline_doc = crate::pipeline::prepare_document(baseline, max_size_bytes)?;
+    let current_doc = crate::pipeline::prepare_document(input, max_size_bytes)?;
+    let changed_count = count_substantive_stable_id_changes(&current_doc, &baseline_doc);
+
+    if changed_count > 0 {
+        tracing::warn!(
+            changed_count,
+            baseline = %baseline.display(),
+            current = %input.display(),
+            "stable id changed for {changed_count} requirement(s) due to non-whitespace change"
+        );
+    }
+
+    Ok(())
+}
 
 /// Execute the convert subcommand.
 ///
@@ -15,10 +108,16 @@ pub fn execute(
     output: Option<&Path>,
     max_size: u64,
     source_profile: Option<&str>,
+    stable_id_baseline: Option<&Path>,
 ) -> Result<(), ForgeError> {
     let max_size_bytes = max_size
         .checked_mul(1024 * 1024)
         .ok_or_else(|| ForgeError::Validation("--max-size value is too large".to_string()))?;
+
+    if let Some(baseline) = stable_id_baseline {
+        validate_regular_file(baseline, "--stable-id-baseline")?;
+        emit_stable_id_change_warning_if_needed(input, baseline, max_size_bytes)?;
+    }
 
     match strategy {
         Strategy::Catalog => {
@@ -39,20 +138,8 @@ pub fn execute(
                     ));
                 }
                 Some(p) => {
-                    // SEC-3: Validate source-profile path exists and is a regular file
                     let profile_path = std::path::Path::new(p);
-                    if !profile_path.exists() {
-                        return Err(ForgeError::Validation(format!(
-                            "--source-profile path '{}' does not exist (not found)",
-                            profile_path.display()
-                        )));
-                    }
-                    if !profile_path.is_file() {
-                        return Err(ForgeError::Validation(format!(
-                            "--source-profile path '{}' is not a regular file (is a directory or special file)",
-                            profile_path.display()
-                        )));
-                    }
+                    validate_regular_file(profile_path, "--source-profile")?;
                     Some(p)
                 }
             };
@@ -72,6 +159,40 @@ mod tests {
     use std::path::Path;
 
     use super::*;
+    use crate::model::{DocumentMetadata, PolicyRequirement};
+    use std::path::PathBuf;
+
+    fn single_requirement_doc(section_title: &str, stable_id: &str) -> PolicyDocument {
+        PolicyDocument {
+            id: "doc".to_string(),
+            metadata: DocumentMetadata {
+                title: "Title".to_string(),
+                version: "1.0.0".to_string(),
+                author: None,
+                date: None,
+                source_path: PathBuf::from("fixture.md"),
+                content_hash: None,
+            },
+            sections: vec![PolicySection {
+                title: section_title.to_string(),
+                heading_level: 1,
+                source_line: 1,
+                body_text: None,
+                children: vec![],
+                requirements: vec![PolicyRequirement {
+                    stable_id: Some(stable_id.to_string()),
+                    text: "Requirement text".to_string(),
+                    source_line: 10,
+                    nesting_depth: 0,
+                    atom_index: 0,
+                    parent_text: None,
+                    citations: vec![],
+                    modality: None,
+                    parameters: vec![],
+                }],
+            }],
+        }
+    }
 
     #[test]
     fn component_strategy_none_source_profile_does_not_error_on_missing_profile() {
@@ -84,6 +205,7 @@ mod tests {
             &OutputFormat::Json,
             None,
             10,
+            None,
             None,
         );
         let err = result.unwrap_err();
@@ -103,6 +225,7 @@ mod tests {
             None,
             10,
             Some(""),
+            None,
         );
         let err = result.unwrap_err();
         assert!(
@@ -120,6 +243,7 @@ mod tests {
             None,
             10,
             Some("   "),
+            None,
         );
         let err = result.unwrap_err();
         assert!(
@@ -135,8 +259,15 @@ mod tests {
         // T026: OutputFormat::Xml should NOT be rejected for catalog strategy.
         // Will fail on file-not-found (test.md doesn't exist), proving the
         // format check no longer blocks XML.
-        let result =
-            execute(Path::new("test.md"), &Strategy::Catalog, &OutputFormat::Xml, None, 10, None);
+        let result = execute(
+            Path::new("test.md"),
+            &Strategy::Catalog,
+            &OutputFormat::Xml,
+            None,
+            10,
+            None,
+            None,
+        );
         let err = result.unwrap_err();
         assert!(
             !err.to_string().contains("not yet supported"),
@@ -147,8 +278,15 @@ mod tests {
     #[test]
     fn component_strategy_xml_format_is_accepted() {
         // T026: OutputFormat::Xml should NOT be rejected for component strategy.
-        let result =
-            execute(Path::new("test.md"), &Strategy::Component, &OutputFormat::Xml, None, 10, None);
+        let result = execute(
+            Path::new("test.md"),
+            &Strategy::Component,
+            &OutputFormat::Xml,
+            None,
+            10,
+            None,
+            None,
+        );
         let err = result.unwrap_err();
         assert!(
             !err.to_string().contains("not yet supported"),
@@ -161,12 +299,37 @@ mod tests {
         // WI-27: YAML format should be accepted (no longer rejected).
         // Will fail on file-not-found (test.md doesn't exist), proving the
         // format check no longer blocks YAML.
-        let result =
-            execute(Path::new("test.md"), &Strategy::Catalog, &OutputFormat::Yaml, None, 10, None);
+        let result = execute(
+            Path::new("test.md"),
+            &Strategy::Catalog,
+            &OutputFormat::Yaml,
+            None,
+            10,
+            None,
+            None,
+        );
         let err = result.unwrap_err();
         assert!(
             !err.to_string().contains("not yet supported"),
             "YAML format should be accepted, not rejected. Got: {err}"
         );
+    }
+
+    #[test]
+    fn substantive_change_count_detects_matching_locator_id_change() {
+        let baseline = single_requirement_doc("Access", "11111111-1111-1111-1111-111111111111");
+        let current = single_requirement_doc("Access", "22222222-2222-2222-2222-222222222222");
+
+        let changed_count = count_substantive_stable_id_changes(&current, &baseline);
+        assert_eq!(changed_count, 1);
+    }
+
+    #[test]
+    fn substantive_change_count_ignores_missing_locator_matches() {
+        let baseline = single_requirement_doc("Access", "11111111-1111-1111-1111-111111111111");
+        let current = single_requirement_doc("Monitoring", "22222222-2222-2222-2222-222222222222");
+
+        let changed_count = count_substantive_stable_id_changes(&current, &baseline);
+        assert_eq!(changed_count, 0);
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -62,6 +62,14 @@ pub enum Commands {
         /// Source profile/baseline reference for component strategy (e.g., path to OSCAL profile JSON)
         #[arg(long)]
         source_profile: Option<String>,
+
+        /// Optional baseline policy used to compare stable IDs and emit substantive-change warnings.
+        ///
+        /// When provided, FORGE computes stable IDs for both documents and emits a warning if
+        /// matching requirement locations have different stable IDs (indicating non-whitespace
+        /// substantive text changes).
+        #[arg(long)]
+        stable_id_baseline: Option<PathBuf>,
     },
 
     /// Export an OSCAL artifact to a different format
@@ -158,16 +166,23 @@ pub enum OutputFormat {
 /// Returns `ForgeError` if the subcommand handler fails.
 pub fn execute(cli: &Cli) -> Result<(), ForgeError> {
     match &cli.command {
-        Commands::Convert { input, strategy, format, output, max_size, source_profile } => {
-            convert::execute(
-                input,
-                strategy,
-                format,
-                output.as_deref(),
-                *max_size,
-                source_profile.as_deref(),
-            )
-        }
+        Commands::Convert {
+            input,
+            strategy,
+            format,
+            output,
+            max_size,
+            source_profile,
+            stable_id_baseline,
+        } => convert::execute(
+            input,
+            strategy,
+            format,
+            output.as_deref(),
+            *max_size,
+            source_profile.as_deref(),
+            stable_id_baseline.as_deref(),
+        ),
         Commands::Export { input, format, output } => {
             export::execute(input, format, output.as_deref())
         }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -111,7 +111,10 @@ fn validate_component_json(
 ///
 /// # Errors
 /// * `Err(ForgeError)` if any pipeline stage fails (ingest, parse, atomize, etc.)
-fn prepare_document(input_path: &Path, max_size_bytes: u64) -> Result<PolicyDocument, ForgeError> {
+pub(crate) fn prepare_document(
+    input_path: &Path,
+    max_size_bytes: u64,
+) -> Result<PolicyDocument, ForgeError> {
     // Step 1: Ingest file
     let ingested = crate::ingest::ingest_file(input_path, max_size_bytes)?;
 

--- a/tests/golden_edge_case_tests.rs
+++ b/tests/golden_edge_case_tests.rs
@@ -68,6 +68,14 @@ fn load_expected_json(path: &Path) -> Value {
 }
 
 fn run_convert(input_path: &Path, strategy: Strategy) -> ConvertRun {
+    run_convert_with_baseline(input_path, strategy, None)
+}
+
+fn run_convert_with_baseline(
+    input_path: &Path,
+    strategy: Strategy,
+    stable_id_baseline: Option<&Path>,
+) -> ConvertRun {
     let temp = TempDir::new().expect("create temp dir");
     let output_path = temp.path().join("out.json");
 
@@ -83,6 +91,10 @@ fn run_convert(input_path: &Path, strategy: Strategy) -> ConvertRun {
 
     if matches!(strategy, Strategy::Component) {
         cmd.arg("--source-profile").arg(SOURCE_PROFILE);
+    }
+
+    if let Some(baseline) = stable_id_baseline {
+        cmd.arg("--stable-id-baseline").arg(baseline);
     }
 
     let output = cmd.output().expect("run forge convert command");
@@ -345,7 +357,7 @@ fn ec06_substantive_change_rotates_stable_ids() {
     let changed = fixture_input("ec06-substantive-change", "input-changed.md");
 
     let run_a = run_convert(&original, Strategy::Component);
-    let run_b = run_convert(&changed, Strategy::Component);
+    let run_b = run_convert_with_baseline(&changed, Strategy::Component, Some(&original));
     assert_eq!(run_a.code, 0, "EC-6 baseline failed: {}", run_a.stderr);
     assert_eq!(run_b.code, 0, "EC-6 changed failed: {}", run_b.stderr);
 
@@ -362,10 +374,7 @@ fn ec06_substantive_change_rotates_stable_ids() {
         "ec06-substantive-change",
         "expected-warnings.txt",
     ));
-    let comparison_warning = format!(
-        "stable id changed for {changed_count} requirement(s) due to non-whitespace change"
-    );
-    assert_expected_warnings(&comparison_warning, &expected_warnings, "EC-6 warnings");
+    assert_expected_warnings(&run_b.stderr, &expected_warnings, "EC-6 warnings");
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add `--stable-id-baseline` to `forge convert` so stable IDs can be compared against a baseline document during CLI execution
- emit first-class stderr warnings when substantive stable-ID changes are detected (`stable id changed for N requirement(s) due to non-whitespace change`)
- update WI-22 edge-case tests to assert EC-6 warnings from actual CLI stderr and keep EC-10 strategy-matrix handling validation-only

## Verification
- cargo test --test golden_edge_case_tests
- cargo test cli::convert::tests
- cargo test cli::tests
- cargo fmt --check
- cargo clippy -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--stable-id-baseline` flag for the convert command to detect and warn about substantive changes in policy requirements when compared against a baseline document.

* **Tests**
  * Expanded test coverage for baseline comparison and change detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->