### PR TITLE
fix: SLSA provenance upload conflicts with release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,7 @@ jobs:
     uses: slsa-framework/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v2.1.0
     with:
       base64-subjects: "${{ needs.hash.outputs.hashes }}"
-      upload-assets: true
+      upload-assets: false
 
   release:
     name: Create Release
@@ -117,11 +117,17 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Download all artifacts
+      - name: Download build artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts
           merge-multiple: true
+
+      - name: Download SLSA provenance
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: multiple.intoto.jsonl
+          path: artifacts
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2


### PR DESCRIPTION
## Summary

- Set `upload-assets: false` on SLSA provenance job to prevent it from racing the release job
- Download the provenance attestation (`multiple.intoto.jsonl`) in the release job alongside build artifacts
- All assets now upload together in a single `softprops/action-gh-release` step

## Problem

The v0.2.0 release failed with:
```
Error: Cannot upload assets to an immutable release.
```

The SLSA provenance job tried to upload `multiple.intoto.jsonl` directly to the release via its own `softprops/action-gh-release`, but the `release` job had already created it.

## Test plan

- [ ] Merge and tag a new release to verify the full pipeline completes