### PR TITLE
refactor: reduce cognitive complexity across 13 SonarQube findings

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
         id: hash
         run: |
           cd artifacts
-          echo "hashes=$(sha256sum * | base64 -w0)" >> "$GITHUB_OUTPUT"
+          echo "hashes=$(sha256sum ./* | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   provenance:
     name: Generate SLSA provenance

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ coverage/
 # === Claude Code ===
 .claude/settings.local.json
 
+# === SonarQube Issues ===
+.sq/
+
 # === Agent Brain ===
 .agent-brain/
 .rusty-brain/

--- a/src/oscal/back_matter.rs
+++ b/src/oscal/back_matter.rs
@@ -149,6 +149,54 @@ fn classify_url(url_opt: Option<&String>) -> UrlClassification {
     }
 }
 
+fn citation_field(text: &str) -> Option<ResourceCitation> {
+    if text.is_empty() { None } else { Some(ResourceCitation { text: text.to_string() }) }
+}
+
+fn build_resource_parts(
+    classification: UrlClassification,
+    citation: &Citation,
+) -> (Vec<Rlink>, Option<ResourceCitation>, Vec<Prop>) {
+    match classification {
+        UrlClassification::Valid(parsed_url) => {
+            let media_type = infer_media_type(&parsed_url);
+            let href = citation.url.as_deref().unwrap_or_default().to_string();
+            let rlinks = vec![Rlink { href, media_type }];
+            (rlinks, citation_field(&citation.text), vec![])
+        }
+        UrlClassification::Malformed(raw_url) => {
+            tracing::warn!(
+                citation_id = %citation.id,
+                url = %raw_url,
+                "Malformed or non-http/https URL preserved with unvalidated annotation"
+            );
+            let rlinks = vec![Rlink { href: raw_url, media_type: None }];
+            let props = vec![Prop {
+                name: "url-status".to_string(),
+                value: "unvalidated".to_string(),
+                ns: None,
+            }];
+            (rlinks, citation_field(&citation.text), props)
+        }
+        UrlClassification::Dangerous(raw_url) => {
+            tracing::warn!(
+                citation_id = %citation.id,
+                url = %raw_url,
+                "Dangerous URL scheme stripped from rlink href (SEC-2)"
+            );
+            let props = vec![Prop {
+                name: "url-status".to_string(),
+                value: "dangerous-scheme-removed".to_string(),
+                ns: None,
+            }];
+            (vec![], citation_field(&citation.text), props)
+        }
+        UrlClassification::None => {
+            (vec![], Some(ResourceCitation { text: citation.text.clone() }), vec![])
+        }
+    }
+}
+
 /// Infer IANA media type from URL path extension.
 fn infer_media_type(url: &url::Url) -> Option<String> {
     let path = std::path::Path::new(url.path());
@@ -221,61 +269,7 @@ pub fn generate_back_matter(
             .map(|req_id| format!("Referenced by requirement {req_id}"));
 
         let classification = classify_url(citation.url.as_ref());
-
-        let (rlinks, citation_field, props) = match classification {
-            UrlClassification::Valid(parsed_url) => {
-                let media_type = infer_media_type(&parsed_url);
-                let href = citation.url.as_deref().unwrap_or_default().to_string();
-                let rlinks = vec![Rlink { href, media_type }];
-                let citation_field = if citation.text.is_empty() {
-                    None
-                } else {
-                    Some(ResourceCitation { text: citation.text.clone() })
-                };
-                (rlinks, citation_field, vec![])
-            }
-            UrlClassification::Malformed(raw_url) => {
-                tracing::warn!(
-                    citation_id = %citation.id,
-                    url = %raw_url,
-                    "Malformed or non-http/https URL preserved with unvalidated annotation"
-                );
-                let rlinks = vec![Rlink { href: raw_url, media_type: None }];
-                let props = vec![Prop {
-                    name: "url-status".to_string(),
-                    value: "unvalidated".to_string(),
-                    ns: None,
-                }];
-                let citation_field = if citation.text.is_empty() {
-                    None
-                } else {
-                    Some(ResourceCitation { text: citation.text.clone() })
-                };
-                (rlinks, citation_field, props)
-            }
-            UrlClassification::Dangerous(raw_url) => {
-                tracing::warn!(
-                    citation_id = %citation.id,
-                    url = %raw_url,
-                    "Dangerous URL scheme stripped from rlink href (SEC-2)"
-                );
-                let props = vec![Prop {
-                    name: "url-status".to_string(),
-                    value: "dangerous-scheme-removed".to_string(),
-                    ns: None,
-                }];
-                let citation_field = if citation.text.is_empty() {
-                    None
-                } else {
-                    Some(ResourceCitation { text: citation.text.clone() })
-                };
-                (vec![], citation_field, props)
-            }
-            UrlClassification::None => {
-                let citation_field = Some(ResourceCitation { text: citation.text.clone() });
-                (vec![], citation_field, vec![])
-            }
-        };
+        let (rlinks, citation_field, props) = build_resource_parts(classification, citation);
 
         resources.push(BackMatterResource {
             uuid,

--- a/src/parameter/mod.rs
+++ b/src/parameter/mod.rs
@@ -177,59 +177,7 @@ fn extract_section_parameters(
     total_params: &mut usize,
 ) -> Result<(), ForgeError> {
     for req in &mut section.requirements {
-        let Some(stable_id) = req.stable_id.clone() else {
-            // Skip requirements without a stable_id (cannot generate param IDs)
-            continue;
-        };
-
-        if req.text.is_empty() {
-            continue;
-        }
-
-        // Idempotence: if parameters were already extracted, skip (SEC-6).
-        // OSCAL placeholders in `req.text` won't match any pattern, so a second
-        // extraction would produce zero params — we preserve the original result.
-        if !req.parameters.is_empty() {
-            *total_params += req.parameters.len();
-            continue;
-        }
-
-        // OSCAL TokenDatatype requires IDs to start with a letter or underscore.
-        // UUID stable_ids may start with a hex digit; prefix with 'p' if needed.
-        let requirement_id = if stable_id.starts_with(|c: char| c.is_alphabetic() || c == '_') {
-            stable_id.clone()
-        } else {
-            format!("p{stable_id}")
-        };
-
-        let (updated_text, mut params) = extract_parameters_from_text(&requirement_id, &req.text)
-            .map_err(|e| {
-            ForgeError::ParameterExtraction(format!(
-                "Failed to extract parameters from requirement '{stable_id}': {e}"
-            ))
-        })?;
-
-        // PolicyParameter.requirement_id must reference the original stable_id for
-        // traceability. The OSCAL-safe prefixed id is only for parameter ID generation.
-        if requirement_id != stable_id {
-            for param in &mut params {
-                param.requirement_id.clone_from(&stable_id);
-            }
-        }
-
-        let param_count = params.len();
-        *total_params += param_count;
-
-        if param_count > 0 {
-            tracing::debug!(
-                requirement_id = %stable_id,
-                param_count,
-                "Parameters extracted from requirement"
-            );
-        }
-
-        req.text = updated_text;
-        req.parameters = params;
+        *total_params += extract_requirement_parameters(req)?;
     }
 
     for child in &mut section.children {
@@ -237,6 +185,56 @@ fn extract_section_parameters(
     }
 
     Ok(())
+}
+
+fn extract_requirement_parameters(
+    req: &mut crate::model::PolicyRequirement,
+) -> Result<usize, ForgeError> {
+    let Some(stable_id) = req.stable_id.clone() else {
+        return Ok(0);
+    };
+
+    if req.text.is_empty() {
+        return Ok(0);
+    }
+
+    if !req.parameters.is_empty() {
+        return Ok(req.parameters.len());
+    }
+
+    let requirement_id = if stable_id.starts_with(|c: char| c.is_alphabetic() || c == '_') {
+        stable_id.clone()
+    } else {
+        format!("p{stable_id}")
+    };
+
+    let (updated_text, mut params) = extract_parameters_from_text(&requirement_id, &req.text)
+        .map_err(|e| {
+            ForgeError::ParameterExtraction(format!(
+                "Failed to extract parameters from requirement '{stable_id}': {e}"
+            ))
+        })?;
+
+    if requirement_id != stable_id {
+        for param in &mut params {
+            param.requirement_id.clone_from(&stable_id);
+        }
+    }
+
+    let param_count = params.len();
+
+    if param_count > 0 {
+        tracing::debug!(
+            requirement_id = %stable_id,
+            param_count,
+            "Parameters extracted from requirement"
+        );
+    }
+
+    req.text = updated_text;
+    req.parameters = params;
+
+    Ok(param_count)
 }
 
 /// Map a `ConstraintType` to its lowercase string label for OSCAL descriptions.

--- a/src/parse/clauses.rs
+++ b/src/parse/clauses.rs
@@ -156,6 +156,231 @@ pub struct ExtractedContent {
     pub paragraphs: Vec<ExtractedParagraph>,
 }
 
+// ── Mutable state containers for event-loop helpers ──────────────────
+
+struct ListState {
+    list_type_stack: Vec<ListType>,
+    item_stack: Vec<(String, usize)>,
+    exclude_depth: usize,
+}
+
+struct TableState {
+    in_table: bool,
+    current_table_source_line: usize,
+    headers: Vec<String>,
+    rows: Vec<Vec<String>>,
+    current_row: Vec<String>,
+    current_cell: String,
+}
+
+struct ParagraphState {
+    in_standalone: bool,
+    text: String,
+    source_line: usize,
+}
+
+// ── Event-handling helpers ───────────────────────────────────────────
+
+fn handle_list_event(
+    event: &Event<'_>,
+    range: &std::ops::Range<usize>,
+    state: &mut ListState,
+    list_items: &mut Vec<ExtractedListItem>,
+    line_starts: &[usize],
+) -> bool {
+    match event {
+        Event::Start(Tag::List(start_num)) => {
+            let list_type =
+                if start_num.is_some() { ListType::Ordered } else { ListType::Unordered };
+            state.list_type_stack.push(list_type);
+            true
+        }
+        Event::End(TagEnd::List(_)) => {
+            state.list_type_stack.pop();
+            true
+        }
+        Event::Start(Tag::Item) => {
+            let source_line = offset_to_line(range.start, line_starts);
+            state.item_stack.push((String::new(), source_line));
+            true
+        }
+        Event::End(TagEnd::Item) => {
+            finalize_list_item(state, list_items);
+            true
+        }
+        Event::Start(Tag::CodeBlock(_) | Tag::BlockQuote(_)) if !state.item_stack.is_empty() => {
+            state.exclude_depth += 1;
+            true
+        }
+        Event::End(TagEnd::CodeBlock | TagEnd::BlockQuote(_)) if !state.item_stack.is_empty() => {
+            state.exclude_depth = state.exclude_depth.saturating_sub(1);
+            true
+        }
+        _ => false,
+    }
+}
+
+fn finalize_list_item(state: &mut ListState, list_items: &mut Vec<ExtractedListItem>) {
+    if let Some((text, source_line)) = state.item_stack.pop() {
+        let trimmed = text.trim();
+        if !trimmed.is_empty() && !state.list_type_stack.is_empty() {
+            let list_type = *state.list_type_stack.last().unwrap();
+            let depth = state.list_type_stack.len() - 1;
+            #[allow(clippy::cast_possible_truncation)]
+            let nesting_depth = depth.min(255) as u8;
+
+            list_items.push(ExtractedListItem {
+                text: trimmed.to_string(),
+                source_line,
+                nesting_depth,
+                list_type,
+            });
+        }
+    }
+}
+
+fn handle_item_text(event: &Event<'_>, state: &mut ListState) -> bool {
+    if state.item_stack.is_empty() || state.exclude_depth != 0 {
+        return false;
+    }
+    match event {
+        Event::Text(text) => {
+            if let Some((item_text, _)) = state.item_stack.last_mut() {
+                item_text.push_str(text);
+            }
+            true
+        }
+        Event::Code(code) => {
+            if let Some((item_text, _)) = state.item_stack.last_mut() {
+                item_text.push_str(code);
+            }
+            true
+        }
+        Event::SoftBreak | Event::HardBreak => {
+            if let Some((item_text, _)) = state.item_stack.last_mut() {
+                item_text.push(' ');
+            }
+            true
+        }
+        Event::End(TagEnd::Paragraph) => {
+            if let Some((item_text, _)) = state.item_stack.last_mut() {
+                let last_is_whitespace =
+                    item_text.chars().next_back().is_some_and(char::is_whitespace);
+                if !last_is_whitespace {
+                    item_text.push(' ');
+                }
+            }
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_table_event(
+    event: &Event<'_>,
+    range: &std::ops::Range<usize>,
+    state: &mut TableState,
+    tables: &mut Vec<ExtractedTable>,
+    line_starts: &[usize],
+) -> bool {
+    match event {
+        Event::Start(Tag::Table(_)) => {
+            state.in_table = true;
+            state.current_table_source_line = offset_to_line(range.start, line_starts);
+            state.headers.clear();
+            state.rows.clear();
+            state.current_row.clear();
+            state.current_cell.clear();
+            true
+        }
+        Event::End(TagEnd::Table) => {
+            tables.push(ExtractedTable {
+                headers: std::mem::take(&mut state.headers),
+                rows: std::mem::take(&mut state.rows),
+                source_line: state.current_table_source_line,
+            });
+            state.in_table = false;
+            true
+        }
+        Event::Start(Tag::TableHead | Tag::TableRow) => {
+            state.current_row.clear();
+            true
+        }
+        Event::End(TagEnd::TableHead) => {
+            state.headers.clone_from(&state.current_row);
+            state.current_row.clear();
+            true
+        }
+        Event::End(TagEnd::TableRow) => {
+            state.rows.push(std::mem::take(&mut state.current_row));
+            true
+        }
+        Event::Start(Tag::TableCell) => {
+            state.current_cell.clear();
+            true
+        }
+        Event::End(TagEnd::TableCell) => {
+            state.current_row.push(state.current_cell.trim().to_string());
+            state.current_cell.clear();
+            true
+        }
+        Event::Text(text) if state.in_table => {
+            state.current_cell.push_str(text);
+            true
+        }
+        Event::Code(code) if state.in_table => {
+            state.current_cell.push_str(code);
+            true
+        }
+        Event::SoftBreak if state.in_table => {
+            state.current_cell.push(' ');
+            true
+        }
+        _ => false,
+    }
+}
+
+fn handle_paragraph_event(
+    event: &Event<'_>,
+    range: &std::ops::Range<usize>,
+    state: &mut ParagraphState,
+    paragraphs: &mut Vec<ExtractedParagraph>,
+    in_item: bool,
+    in_table: bool,
+    line_starts: &[usize],
+) -> bool {
+    match event {
+        Event::Start(Tag::Paragraph) if !in_item && !in_table => {
+            state.in_standalone = true;
+            state.text.clear();
+            state.source_line = offset_to_line(range.start, line_starts);
+            true
+        }
+        Event::End(TagEnd::Paragraph) if state.in_standalone => {
+            let trimmed = state.text.trim().to_string();
+            if !trimmed.is_empty() {
+                paragraphs
+                    .push(ExtractedParagraph { text: trimmed, source_line: state.source_line });
+            }
+            state.in_standalone = false;
+            true
+        }
+        Event::Text(text) if state.in_standalone => {
+            state.text.push_str(text);
+            true
+        }
+        Event::Code(code) if state.in_standalone => {
+            state.text.push_str(code);
+            true
+        }
+        Event::SoftBreak if state.in_standalone => {
+            state.text.push(' ');
+            true
+        }
+        _ => false,
+    }
+}
+
 // ── Functions ──────────────────────────────────────────────────────────
 
 /// Extract list items, tables, and paragraphs from Markdown content.
@@ -195,186 +420,47 @@ pub struct ExtractedContent {
 /// 5. Capture standalone paragraphs (not inside items or tables)
 /// 6. Strip inline formatting by processing only Text/Code/SoftBreak events
 /// 7. Map byte offsets to 1-based line numbers via line-starts lookup table
-#[allow(clippy::too_many_lines)]
 pub fn extract_clauses(content: &str) -> Result<ExtractedContent, ForgeError> {
-    // Enable GFM table support (SEC-7)
     let options = Options::ENABLE_TABLES;
     let parser = Parser::new_ext(content, options).into_offset_iter();
-
-    // Build line-starts lookup table for O(log n) line number mapping (M-4)
     let line_starts = build_line_starts(content);
 
-    // Initialize result vectors
     let mut list_items: Vec<ExtractedListItem> = Vec::new();
     let mut tables: Vec<ExtractedTable> = Vec::new();
     let mut paragraphs: Vec<ExtractedParagraph> = Vec::new();
 
-    // List extraction state (T017)
-    let mut list_type_stack: Vec<ListType> = Vec::new(); // Depth tracking via stack
-    let mut item_stack: Vec<(String, usize)> = Vec::new(); // Stack of (text, source_line) for nested items
-    let mut exclude_depth: usize = 0; // T019: Track CodeBlock/BlockQuote nesting
+    let mut list_state =
+        ListState { list_type_stack: Vec::new(), item_stack: Vec::new(), exclude_depth: 0 };
+    let mut table_state = TableState {
+        in_table: false,
+        current_table_source_line: 0,
+        headers: Vec::new(),
+        rows: Vec::new(),
+        current_row: Vec::new(),
+        current_cell: String::new(),
+    };
+    let mut para_state =
+        ParagraphState { in_standalone: false, text: String::new(), source_line: 0 };
 
-    // Table extraction state (T028)
-    let mut in_table = false;
-    let mut current_table_source_line: usize = 0;
-    let mut table_headers: Vec<String> = Vec::new();
-    let mut table_rows: Vec<Vec<String>> = Vec::new();
-    let mut current_row: Vec<String> = Vec::new();
-    let mut current_cell: String = String::new();
-
-    // Paragraph extraction state (T035)
-    let mut in_standalone_paragraph = false;
-    let mut para_text = String::new();
-    let mut para_source_line: usize = 0;
-    // Process events (SEC-5: single-pass O(n))
     for (event, range) in parser {
-        match event {
-            // T017: List start/end — push/pop list type for depth tracking
-            Event::Start(Tag::List(start_num)) => {
-                let list_type =
-                    if start_num.is_some() { ListType::Ordered } else { ListType::Unordered };
-                list_type_stack.push(list_type);
-            }
-            Event::End(TagEnd::List(_)) => {
-                list_type_stack.pop();
-            }
-
-            // T017: Item start/end — accumulate text within items
-            Event::Start(Tag::Item) => {
-                // Push a new item onto the stack
-                let source_line = offset_to_line(range.start, &line_starts);
-                item_stack.push((String::new(), source_line));
-            }
-            Event::End(TagEnd::Item) => {
-                // Pop and save the completed item
-                if let Some((text, source_line)) = item_stack.pop() {
-                    // T016: Exclude empty items (only whitespace)
-                    let trimmed = text.trim();
-                    if !trimmed.is_empty() && !list_type_stack.is_empty() {
-                        // SAFETY: guarded by !list_type_stack.is_empty() check on previous line
-                        let list_type = *list_type_stack.last().unwrap();
-                        // T017: nesting_depth with saturation at 255 (SEC-4)
-                        let depth = list_type_stack.len() - 1;
-                        #[allow(clippy::cast_possible_truncation)]
-                        let nesting_depth = depth.min(255) as u8;
-
-                        list_items.push(ExtractedListItem {
-                            text: trimmed.to_string(),
-                            source_line,
-                            nesting_depth,
-                            list_type,
-                        });
-                    }
-                }
-            }
-
-            // T019: Exclude code blocks and blockquotes within items (EC-8)
-            Event::Start(Tag::CodeBlock(_) | Tag::BlockQuote(_)) if !item_stack.is_empty() => {
-                exclude_depth += 1;
-            }
-            Event::End(TagEnd::CodeBlock | TagEnd::BlockQuote(_)) if !item_stack.is_empty() => {
-                exclude_depth = exclude_depth.saturating_sub(1);
-            }
-
-            // T018: Text accumulation within list items (SEC-3: strip formatting)
-            // Accumulate text into the current (deepest) item
-            Event::Text(text) if !item_stack.is_empty() && exclude_depth == 0 => {
-                if let Some((item_text, _)) = item_stack.last_mut() {
-                    item_text.push_str(&text);
-                }
-            }
-            Event::Code(code) if !item_stack.is_empty() && exclude_depth == 0 => {
-                if let Some((item_text, _)) = item_stack.last_mut() {
-                    item_text.push_str(&code);
-                }
-            }
-            Event::SoftBreak if !item_stack.is_empty() && exclude_depth == 0 => {
-                if let Some((item_text, _)) = item_stack.last_mut() {
-                    item_text.push(' '); // T018: SoftBreak → space
-                }
-            }
-            Event::HardBreak if !item_stack.is_empty() && exclude_depth == 0 => {
-                if let Some((item_text, _)) = item_stack.last_mut() {
-                    item_text.push(' '); // T018: HardBreak → space
-                }
-            }
-            Event::End(TagEnd::Paragraph) if !item_stack.is_empty() && exclude_depth == 0 => {
-                if let Some((item_text, _)) = item_stack.last_mut() {
-                    // Add space between paragraphs if text doesn't already end with whitespace
-                    let last_is_whitespace =
-                        item_text.chars().next_back().is_some_and(char::is_whitespace);
-                    if !last_is_whitespace {
-                        item_text.push(' '); // T018: Paragraph boundary → space
-                    }
-                }
-            }
-
-            // T028: Table extraction — track table/head/row/cell events
-            Event::Start(Tag::Table(_)) => {
-                in_table = true;
-                current_table_source_line = offset_to_line(range.start, &line_starts);
-                table_headers.clear();
-                table_rows.clear();
-                current_row.clear();
-                current_cell.clear();
-            }
-            Event::End(TagEnd::Table) => {
-                tables.push(ExtractedTable {
-                    headers: std::mem::take(&mut table_headers),
-                    rows: std::mem::take(&mut table_rows),
-                    source_line: current_table_source_line,
-                });
-                in_table = false;
-            }
-            Event::Start(Tag::TableHead | Tag::TableRow) => {
-                current_row.clear();
-            }
-            Event::End(TagEnd::TableHead) => {
-                table_headers.clone_from(&current_row);
-                current_row.clear();
-            }
-            Event::End(TagEnd::TableRow) => {
-                table_rows.push(std::mem::take(&mut current_row));
-            }
-            Event::Start(Tag::TableCell) => {
-                current_cell.clear();
-            }
-            Event::End(TagEnd::TableCell) => {
-                current_row.push(current_cell.trim().to_string());
-                current_cell.clear();
-            }
-            // Text/Code within table cells (SEC-3: inline formatting stripped)
-            Event::Text(text) if in_table => {
-                current_cell.push_str(&text);
-            }
-            Event::Code(code) if in_table => {
-                current_cell.push_str(&code);
-            }
-            Event::SoftBreak if in_table => {
-                current_cell.push(' ');
-            }
-
-            // T035: Standalone paragraph capture (S-2, SEC-3)
-            Event::Start(Tag::Paragraph) if item_stack.is_empty() && !in_table => {
-                in_standalone_paragraph = true;
-                para_text.clear();
-                para_source_line = offset_to_line(range.start, &line_starts);
-            }
-            Event::End(TagEnd::Paragraph) if in_standalone_paragraph => {
-                let trimmed = para_text.trim().to_string();
-                if !trimmed.is_empty() {
-                    paragraphs
-                        .push(ExtractedParagraph { text: trimmed, source_line: para_source_line });
-                }
-                in_standalone_paragraph = false;
-            }
-            Event::Text(text) if in_standalone_paragraph => para_text.push_str(&text),
-            Event::Code(code) if in_standalone_paragraph => para_text.push_str(&code),
-            Event::SoftBreak if in_standalone_paragraph => para_text.push(' '),
-
-            // Ignore all other events (formatting tags, etc.)
-            _ => {}
+        if handle_list_event(&event, &range, &mut list_state, &mut list_items, &line_starts) {
+            continue;
         }
+        if handle_item_text(&event, &mut list_state) {
+            continue;
+        }
+        if handle_table_event(&event, &range, &mut table_state, &mut tables, &line_starts) {
+            continue;
+        }
+        handle_paragraph_event(
+            &event,
+            &range,
+            &mut para_state,
+            &mut paragraphs,
+            !list_state.item_stack.is_empty(),
+            table_state.in_table,
+            &line_starts,
+        );
     }
 
     // Sort items by source_line to maintain document order.

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -130,7 +130,6 @@ pub fn extract_sections(content: &str) -> Result<Vec<SectionNode>, ForgeError> {
                     children: Vec::new(),
                 };
 
-                // Pop stack until top has level < current_level
                 pop_to_parent(&mut stack, &mut roots, current_level);
 
                 stack.push((current_level, node));
@@ -141,38 +140,23 @@ pub fn extract_sections(content: &str) -> Result<Vec<SectionNode>, ForgeError> {
             Event::Code(code) if in_heading => {
                 title_buf.push_str(&code);
             }
-            // Body text accumulation (between headings, per R-6)
-            Event::Text(text) if !in_heading => {
-                if let Some((_, node)) = stack.last_mut() {
-                    node.body_text.get_or_insert_with(String::new).push_str(&text);
-                }
+            Event::Text(ref text) if !in_heading => {
+                accumulate_body_text(&Event::Text(text.clone()), &mut stack);
             }
-            Event::Code(code) if !in_heading => {
-                if let Some((_, node)) = stack.last_mut() {
-                    let body = node.body_text.get_or_insert_with(String::new);
-                    body.push('`');
-                    body.push_str(&code);
-                    body.push('`');
-                }
+            Event::Code(ref code) if !in_heading => {
+                accumulate_body_text(&Event::Code(code.clone()), &mut stack);
             }
-            Event::SoftBreak | Event::HardBreak if !in_heading => {
-                if let Some((_, node)) = stack.last_mut() {
-                    node.body_text.get_or_insert_with(String::new).push('\n');
-                }
-            }
-            Event::End(TagEnd::Paragraph | TagEnd::Item | TagEnd::List(_)) if !in_heading => {
-                if let Some((_, node)) = stack.last_mut() {
-                    let body = node.body_text.get_or_insert_with(String::new);
-                    if !body.is_empty() && !body.ends_with('\n') {
-                        body.push('\n');
-                    }
-                }
+            Event::SoftBreak
+            | Event::HardBreak
+            | Event::End(TagEnd::Paragraph | TagEnd::Item | TagEnd::List(_))
+                if !in_heading =>
+            {
+                accumulate_body_text(&event, &mut stack);
             }
             _ => {}
         }
     }
 
-    // Drain remaining stack
     drain_stack(&mut stack, &mut roots);
 
     for root in &mut roots {
@@ -180,6 +164,33 @@ pub fn extract_sections(content: &str) -> Result<Vec<SectionNode>, ForgeError> {
     }
 
     Ok(roots)
+}
+
+fn accumulate_body_text(event: &Event<'_>, stack: &mut [(u8, SectionNode)]) {
+    let Some((_, node)) = stack.last_mut() else {
+        return;
+    };
+    match event {
+        Event::Text(text) => {
+            node.body_text.get_or_insert_with(String::new).push_str(text);
+        }
+        Event::Code(code) => {
+            let body = node.body_text.get_or_insert_with(String::new);
+            body.push('`');
+            body.push_str(code);
+            body.push('`');
+        }
+        Event::SoftBreak | Event::HardBreak => {
+            node.body_text.get_or_insert_with(String::new).push('\n');
+        }
+        Event::End(TagEnd::Paragraph | TagEnd::Item | TagEnd::List(_)) => {
+            let body = node.body_text.get_or_insert_with(String::new);
+            if !body.is_empty() && !body.ends_with('\n') {
+                body.push('\n');
+            }
+        }
+        _ => {}
+    }
 }
 
 /// Pop stack entries with level >= `current_level`, attaching them to their

--- a/src/parse/mod.rs
+++ b/src/parse/mod.rs
@@ -140,13 +140,9 @@ pub fn extract_sections(content: &str) -> Result<Vec<SectionNode>, ForgeError> {
             Event::Code(code) if in_heading => {
                 title_buf.push_str(&code);
             }
-            Event::Text(ref text) if !in_heading => {
-                accumulate_body_text(&Event::Text(text.clone()), &mut stack);
-            }
-            Event::Code(ref code) if !in_heading => {
-                accumulate_body_text(&Event::Code(code.clone()), &mut stack);
-            }
-            Event::SoftBreak
+            Event::Text(_)
+            | Event::Code(_)
+            | Event::SoftBreak
             | Event::HardBreak
             | Event::End(TagEnd::Paragraph | TagEnd::Item | TagEnd::List(_))
                 if !in_heading =>

--- a/src/round_trip/comparator.rs
+++ b/src/round_trip/comparator.rs
@@ -35,7 +35,6 @@ fn compare_values(
 ) {
     match (expected, actual) {
         (Value::Object(exp_map), Value::Object(act_map)) => {
-            // Keys in expected but missing in actual
             for key in exp_map.keys() {
                 let child_path = format!("{path}/{key}");
                 match act_map.get(key) {
@@ -43,61 +42,32 @@ fn compare_values(
                         compare_values(&exp_map[key], act_val, &child_path, rules, divergences);
                     }
                     None => {
-                        // EC-2: empty array vs absent key is Acceptable
-                        if exp_map[key].as_array().is_some_and(Vec::is_empty) {
-                            divergences.push(Divergence {
-                                json_path: child_path,
-                                expected: exp_map[key].clone(),
-                                actual: Value::Null,
-                                classification: DivergenceClass::Acceptable,
-                                description: "Empty array in expected vs absent key in actual"
-                                    .to_string(),
-                                resolution: None,
-                            });
-                        } else {
-                            divergences.push(Divergence {
-                                json_path: child_path,
-                                expected: exp_map[key].clone(),
-                                actual: Value::Null,
-                                classification: DivergenceClass::ForgeFix,
-                                description: "Key present in expected but absent in actual"
-                                    .to_string(),
-                                resolution: None,
-                            });
-                        }
+                        divergences.push(missing_key_divergence(
+                            child_path,
+                            exp_map[key].clone(),
+                            Value::Null,
+                            &exp_map[key],
+                            "Empty array in expected vs absent key in actual",
+                            "Key present in expected but absent in actual",
+                        ));
                     }
                 }
             }
-            // Keys in actual but missing in expected
             for key in act_map.keys() {
                 if !exp_map.contains_key(key) {
                     let child_path = format!("{path}/{key}");
-                    // Absent key in expected vs empty array in actual is also Acceptable
-                    if act_map[key].as_array().is_some_and(Vec::is_empty) {
-                        divergences.push(Divergence {
-                            json_path: child_path,
-                            expected: Value::Null,
-                            actual: act_map[key].clone(),
-                            classification: DivergenceClass::Acceptable,
-                            description: "Absent key in expected vs empty array in actual"
-                                .to_string(),
-                            resolution: None,
-                        });
-                    } else {
-                        divergences.push(Divergence {
-                            json_path: child_path,
-                            expected: Value::Null,
-                            actual: act_map[key].clone(),
-                            classification: DivergenceClass::ForgeFix,
-                            description: "Extra key in actual not present in expected".to_string(),
-                            resolution: None,
-                        });
-                    }
+                    divergences.push(missing_key_divergence(
+                        child_path,
+                        Value::Null,
+                        act_map[key].clone(),
+                        &act_map[key],
+                        "Absent key in expected vs empty array in actual",
+                        "Extra key in actual not present in expected",
+                    ));
                 }
             }
         }
         (Value::Array(exp_arr), Value::Array(act_arr)) => {
-            // Determine if this is an unordered array path
             let key_name = path.rsplit('/').next().unwrap_or("");
             if rules.unordered_array_paths.contains(key_name) {
                 compare_unordered_array(exp_arr, act_arr, path, rules, divergences);
@@ -122,6 +92,23 @@ fn compare_values(
             }
         }
     }
+}
+
+fn missing_key_divergence(
+    json_path: String,
+    expected: Value,
+    actual: Value,
+    present_value: &Value,
+    empty_array_desc: &str,
+    non_empty_desc: &str,
+) -> Divergence {
+    let is_empty_array = present_value.as_array().is_some_and(Vec::is_empty);
+    let (classification, description) = if is_empty_array {
+        (DivergenceClass::Acceptable, empty_array_desc.to_string())
+    } else {
+        (DivergenceClass::ForgeFix, non_empty_desc.to_string())
+    };
+    Divergence { json_path, expected, actual, classification, description, resolution: None }
 }
 
 fn compare_ordered_array(
@@ -217,49 +204,63 @@ fn find_matching_element(
     act_arr: &[Value],
     already_matched: &[bool],
 ) -> Option<usize> {
-    // 1. Try exact equality first (handles reordered links, duplicate identity props)
-    for (i, act_elem) in act_arr.iter().enumerate() {
-        if already_matched[i] {
-            continue;
-        }
-        if act_elem == exp_elem {
-            return Some(i);
-        }
+    if let Some(i) = find_by_exact_equality(exp_elem, act_arr, already_matched) {
+        return Some(i);
     }
 
-    // 2. Try uuid match
     if let Some(exp_uuid) = exp_elem.get("uuid").and_then(Value::as_str) {
-        for (i, act_elem) in act_arr.iter().enumerate() {
-            if already_matched[i] {
-                continue;
-            }
-            if act_elem.get("uuid").and_then(Value::as_str) == Some(exp_uuid) {
-                return Some(i);
-            }
-        }
-        return None; // uuid specified but not found
+        return find_by_uuid(exp_uuid, act_arr, already_matched);
     }
 
-    // 3. Try name+ns composite match (for props)
     if let Some(exp_name) = exp_elem.get("name").and_then(Value::as_str) {
         let exp_ns = exp_elem.get("ns").and_then(Value::as_str);
-        for (i, act_elem) in act_arr.iter().enumerate() {
-            if already_matched[i] {
-                continue;
-            }
-            let act_name = act_elem.get("name").and_then(Value::as_str);
-            let act_ns = act_elem.get("ns").and_then(Value::as_str);
-            if act_name == Some(exp_name) && act_ns == exp_ns {
-                return Some(i);
-            }
-        }
-        return None; // name specified but not found
+        return find_by_name_ns(exp_name, exp_ns, act_arr, already_matched);
     }
 
-    // 4. Positional fallback: match first unmatched element.
-    // Note: elements without identity keys or exact match may be paired arbitrarily,
-    // producing confusing (but never silently acceptable) divergence descriptions.
-    act_arr.iter().enumerate().map(|(i, _)| i).find(|&i| !already_matched[i])
+    find_positional_fallback(already_matched)
+}
+
+fn find_by_exact_equality(
+    exp_elem: &Value,
+    act_arr: &[Value],
+    already_matched: &[bool],
+) -> Option<usize> {
+    act_arr
+        .iter()
+        .enumerate()
+        .find(|(i, act_elem)| !already_matched[*i] && *act_elem == exp_elem)
+        .map(|(i, _)| i)
+}
+
+fn find_by_uuid(exp_uuid: &str, act_arr: &[Value], already_matched: &[bool]) -> Option<usize> {
+    act_arr
+        .iter()
+        .enumerate()
+        .find(|(i, act_elem)| {
+            !already_matched[*i] && act_elem.get("uuid").and_then(Value::as_str) == Some(exp_uuid)
+        })
+        .map(|(i, _)| i)
+}
+
+fn find_by_name_ns(
+    exp_name: &str,
+    exp_ns: Option<&str>,
+    act_arr: &[Value],
+    already_matched: &[bool],
+) -> Option<usize> {
+    act_arr
+        .iter()
+        .enumerate()
+        .find(|(i, act_elem)| {
+            !already_matched[*i]
+                && act_elem.get("name").and_then(Value::as_str) == Some(exp_name)
+                && act_elem.get("ns").and_then(Value::as_str) == exp_ns
+        })
+        .map(|(i, _)| i)
+}
+
+fn find_positional_fallback(already_matched: &[bool]) -> Option<usize> {
+    already_matched.iter().position(|matched| !matched)
 }
 
 fn summarize_value(v: &Value) -> String {

--- a/src/testing/semantic_eq.rs
+++ b/src/testing/semantic_eq.rs
@@ -56,73 +56,98 @@ fn escape_json_pointer_token(token: &str) -> String {
 fn compare_values(expected: &Value, actual: &Value, path: &str, diffs: &mut Vec<EquivalenceDiff>) {
     match (expected, actual) {
         (Value::Object(exp_map), Value::Object(act_map)) => {
-            // Check for missing keys (in expected but not in actual)
-            for key in exp_map.keys() {
-                let child_path = format!("{path}/{}", escape_json_pointer_token(key));
-                if let Some(act_val) = act_map.get(key) {
-                    compare_values(&exp_map[key], act_val, &child_path, diffs);
-                } else {
-                    diffs.push(EquivalenceDiff {
-                        path: child_path,
-                        description: format!("missing key \"{key}\""),
-                        expected: Some(format_value(&exp_map[key])),
-                        actual: None,
-                    });
-                }
-            }
-            // Check for extra keys (in actual but not in expected)
-            for key in act_map.keys() {
-                if !exp_map.contains_key(key) {
-                    let child_path = format!("{path}/{}", escape_json_pointer_token(key));
-                    diffs.push(EquivalenceDiff {
-                        path: child_path,
-                        description: format!("extra key \"{key}\""),
-                        expected: None,
-                        actual: Some(format_value(&act_map[key])),
-                    });
-                }
-            }
+            compare_objects(exp_map, act_map, path, diffs);
         }
         (Value::Array(exp_arr), Value::Array(act_arr)) => {
-            if exp_arr.len() != act_arr.len() {
-                diffs.push(EquivalenceDiff {
-                    path: path.to_string(),
-                    description: format!(
-                        "array length mismatch: expected {}, got {}",
-                        exp_arr.len(),
-                        act_arr.len()
-                    ),
-                    expected: Some(exp_arr.len().to_string()),
-                    actual: Some(act_arr.len().to_string()),
-                });
-            }
-            let min_len = exp_arr.len().min(act_arr.len());
-            for i in 0..min_len {
-                let child_path = format!("{path}/{i}");
-                compare_values(&exp_arr[i], &act_arr[i], &child_path, diffs);
-            }
+            compare_arrays(exp_arr, act_arr, path, diffs);
         }
         _ => {
-            // Type mismatch or value mismatch for primitives (String, Number, Bool, Null)
-            if expected != actual {
-                let description = if discriminant_name(expected) == discriminant_name(actual) {
-                    "value mismatch".to_string()
-                } else {
-                    format!(
-                        "type mismatch: expected {}, got {}",
-                        discriminant_name(expected),
-                        discriminant_name(actual)
-                    )
-                };
-                diffs.push(EquivalenceDiff {
-                    path: path.to_string(),
-                    description,
-                    expected: Some(format_value(expected)),
-                    actual: Some(format_value(actual)),
-                });
-            }
+            compare_primitives(expected, actual, path, diffs);
         }
     }
+}
+
+fn compare_objects(
+    exp_map: &serde_json::Map<String, Value>,
+    act_map: &serde_json::Map<String, Value>,
+    path: &str,
+    diffs: &mut Vec<EquivalenceDiff>,
+) {
+    for key in exp_map.keys() {
+        let child_path = format!("{path}/{}", escape_json_pointer_token(key));
+        if let Some(act_val) = act_map.get(key) {
+            compare_values(&exp_map[key], act_val, &child_path, diffs);
+        } else {
+            diffs.push(EquivalenceDiff {
+                path: child_path,
+                description: format!("missing key \"{key}\""),
+                expected: Some(format_value(&exp_map[key])),
+                actual: None,
+            });
+        }
+    }
+    for key in act_map.keys() {
+        if !exp_map.contains_key(key) {
+            let child_path = format!("{path}/{}", escape_json_pointer_token(key));
+            diffs.push(EquivalenceDiff {
+                path: child_path,
+                description: format!("extra key \"{key}\""),
+                expected: None,
+                actual: Some(format_value(&act_map[key])),
+            });
+        }
+    }
+}
+
+fn compare_arrays(
+    exp_arr: &[Value],
+    act_arr: &[Value],
+    path: &str,
+    diffs: &mut Vec<EquivalenceDiff>,
+) {
+    if exp_arr.len() != act_arr.len() {
+        diffs.push(EquivalenceDiff {
+            path: path.to_string(),
+            description: format!(
+                "array length mismatch: expected {}, got {}",
+                exp_arr.len(),
+                act_arr.len()
+            ),
+            expected: Some(exp_arr.len().to_string()),
+            actual: Some(act_arr.len().to_string()),
+        });
+    }
+    let min_len = exp_arr.len().min(act_arr.len());
+    for i in 0..min_len {
+        let child_path = format!("{path}/{i}");
+        compare_values(&exp_arr[i], &act_arr[i], &child_path, diffs);
+    }
+}
+
+fn compare_primitives(
+    expected: &Value,
+    actual: &Value,
+    path: &str,
+    diffs: &mut Vec<EquivalenceDiff>,
+) {
+    if expected == actual {
+        return;
+    }
+    let description = if discriminant_name(expected) == discriminant_name(actual) {
+        "value mismatch".to_string()
+    } else {
+        format!(
+            "type mismatch: expected {}, got {}",
+            discriminant_name(expected),
+            discriminant_name(actual)
+        )
+    };
+    diffs.push(EquivalenceDiff {
+        path: path.to_string(),
+        description,
+        expected: Some(format_value(expected)),
+        actual: Some(format_value(actual)),
+    });
 }
 
 /// Return a human-readable type name for a `serde_json::Value` variant.

--- a/src/trace/formatter.rs
+++ b/src/trace/formatter.rs
@@ -25,19 +25,8 @@ pub fn format_trace_table(report: &TraceReport) -> String {
             let (section, line) = match &entry.trace {
                 Some(meta) => {
                     let section = strip_control_chars(&meta.source_section);
-                    let line = if meta.source_line == 0 && entry.element_type == ElementType::Group
-                    {
-                        "\u{2014}".to_string() // em dash for groups
-                    } else if meta.source_line == 0 {
-                        "0 \u{26A0}".to_string() // missing line on non-group element
-                    } else {
-                        let line_str = meta.source_line.to_string();
-                        if validate_line_reference(meta.source_line, source_line_count) {
-                            line_str
-                        } else {
-                            format!("{line_str} \u{26A0}")
-                        }
-                    };
+                    let line =
+                        format_source_line(meta.source_line, entry.element_type, source_line_count);
                     (section, line)
                 }
                 None => ("[unmapped]".to_string(), "[unmapped]".to_string()),
@@ -129,6 +118,25 @@ pub fn format_trace_table(report: &TraceReport) -> String {
     );
 
     output
+}
+
+fn format_source_line(
+    source_line: usize,
+    element_type: ElementType,
+    source_line_count: usize,
+) -> String {
+    if source_line == 0 && element_type == ElementType::Group {
+        return "\u{2014}".to_string();
+    }
+    if source_line == 0 {
+        return "0 \u{26A0}".to_string();
+    }
+    let line_str = source_line.to_string();
+    if validate_line_reference(source_line, source_line_count) {
+        line_str
+    } else {
+        format!("{line_str} \u{26A0}")
+    }
 }
 
 #[cfg(test)]

--- a/tests/component_pipeline_test.rs
+++ b/tests/component_pipeline_test.rs
@@ -267,6 +267,36 @@ fn component_pipeline_source_file_prop_is_filename_only() {
 
 // ─── T025: Cross-Artifact Consistency Test ───────────────────────────────
 
+fn extract_catalog_control_ids(catalog_json: &serde_json::Value) -> Vec<String> {
+    catalog_json["catalog"]["groups"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|group| {
+            group["controls"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|control| control["id"].as_str().map(String::from))
+        })
+        .collect()
+}
+
+fn extract_component_control_ids(component_json: &serde_json::Value) -> Vec<String> {
+    component_json["component-definition"]["components"][0]["control-implementations"]
+        .as_array()
+        .into_iter()
+        .flatten()
+        .flat_map(|entry| {
+            entry["implemented-requirements"]
+                .as_array()
+                .into_iter()
+                .flatten()
+                .filter_map(|req| req["control-id"].as_str().map(String::from))
+        })
+        .collect()
+}
+
 #[test]
 fn control_ids_match_between_catalog_and_component() {
     let fixture = Path::new("tests/fixtures/full_policy.md");
@@ -290,36 +320,8 @@ fn control_ids_match_between_catalog_and_component() {
     let component_json: serde_json::Value =
         serde_json::from_str(&component_result.content).unwrap();
 
-    // Extract control-ids from Catalog (groups → controls → id)
-    let mut catalog_ids: Vec<String> = Vec::new();
-    if let Some(groups) = catalog_json["catalog"]["groups"].as_array() {
-        for group in groups {
-            if let Some(controls) = group["controls"].as_array() {
-                for control in controls {
-                    if let Some(id) = control["id"].as_str() {
-                        catalog_ids.push(id.to_string());
-                    }
-                }
-            }
-        }
-    }
-
-    // Extract control-ids from Component Definition (control-implementations → implemented-requirements → control-id)
-    let mut component_ids: Vec<String> = Vec::new();
-    if let Some(ci) =
-        component_json["component-definition"]["components"][0]["control-implementations"]
-            .as_array()
-    {
-        for entry in ci {
-            if let Some(impl_reqs) = entry["implemented-requirements"].as_array() {
-                for req in impl_reqs {
-                    if let Some(id) = req["control-id"].as_str() {
-                        component_ids.push(id.to_string());
-                    }
-                }
-            }
-        }
-    }
+    let catalog_ids = extract_catalog_control_ids(&catalog_json);
+    let component_ids = extract_component_control_ids(&component_json);
 
     assert_eq!(
         catalog_ids.len(),

--- a/tests/e2e_release_test.rs
+++ b/tests/e2e_release_test.rs
@@ -420,6 +420,22 @@ fn test_m11_no_arbitrary_remarks() {
 // User Story 2 — Component E2E
 // =========================================================================
 
+fn collect_all_prose(catalog_json: &serde_json::Value) -> Vec<String> {
+    let groups = catalog_json["catalog"]["groups"].as_array().expect("catalog should have groups");
+    groups
+        .iter()
+        .flat_map(|group| {
+            group["controls"].as_array().into_iter().flatten().flat_map(|control| {
+                control["parts"]
+                    .as_array()
+                    .into_iter()
+                    .flatten()
+                    .filter_map(|part| part["prose"].as_str().map(String::from))
+            })
+        })
+        .collect()
+}
+
 /// T017 [US2] M-2, AC-2: Atomize compound statements into separate controls.
 #[test]
 fn test_m2_atomize_compound_statements() {
@@ -428,24 +444,7 @@ fn test_m2_atomize_compound_statements() {
     assert!(input.exists(), "full_policy.md fixture should exist");
 
     let json = convert_catalog_json(input);
-
-    let groups = json["catalog"]["groups"].as_array().expect("catalog should have groups");
-
-    // Collect all control prose
-    let mut all_prose: Vec<String> = Vec::new();
-    for group in groups {
-        if let Some(controls) = group["controls"].as_array() {
-            for control in controls {
-                if let Some(parts) = control["parts"].as_array() {
-                    for part in parts {
-                        if let Some(prose) = part["prose"].as_str() {
-                            all_prose.push(prose.to_string());
-                        }
-                    }
-                }
-            }
-        }
-    }
+    let all_prose = collect_all_prose(&json);
 
     // full_policy.md line 39: "Systems must log all authentication attempts and must log all privilege escalation events"
     // This compound statement should be atomized into separate controls

--- a/tests/golden_edge_case_tests.rs
+++ b/tests/golden_edge_case_tests.rs
@@ -169,47 +169,46 @@ fn assert_expected_output(actual: &Value, expected_path: &Path, context: &str) {
     );
 }
 
-fn extract_stable_ids(output: &Value) -> BTreeMap<String, String> {
+fn extract_catalog_stable_ids(output: &Value) -> BTreeMap<String, String> {
     let mut ids = BTreeMap::new();
+    let groups = output.pointer("/catalog/groups").and_then(Value::as_array);
+    for group in groups.into_iter().flatten() {
+        let controls = group.get("controls").and_then(Value::as_array);
+        for control in controls.into_iter().flatten() {
+            if let (Some(id), Some(uuid)) = (
+                control.get("id").and_then(Value::as_str),
+                control.get("uuid").and_then(Value::as_str),
+            ) {
+                ids.insert(id.to_string(), uuid.to_string());
+            }
+        }
+    }
+    ids
+}
 
-    if let Some(groups) = output.pointer("/catalog/groups").and_then(Value::as_array) {
-        for group in groups {
-            if let Some(controls) = group.get("controls").and_then(Value::as_array) {
-                for control in controls {
-                    if let (Some(id), Some(uuid)) = (
-                        control.get("id").and_then(Value::as_str),
-                        control.get("uuid").and_then(Value::as_str),
-                    ) {
-                        ids.insert(id.to_string(), uuid.to_string());
-                    }
+fn extract_component_stable_ids(output: &Value) -> BTreeMap<String, String> {
+    let mut ids = BTreeMap::new();
+    let components = output.pointer("/component-definition/components").and_then(Value::as_array);
+    for component in components.into_iter().flatten() {
+        let impls = component.get("control-implementations").and_then(Value::as_array);
+        for ci in impls.into_iter().flatten() {
+            let reqs = ci.get("implemented-requirements").and_then(Value::as_array);
+            for req in reqs.into_iter().flatten() {
+                if let (Some(control_id), Some(uuid)) = (
+                    req.get("control-id").and_then(Value::as_str),
+                    req.get("uuid").and_then(Value::as_str),
+                ) {
+                    ids.insert(control_id.to_string(), uuid.to_string());
                 }
             }
         }
     }
+    ids
+}
 
-    if let Some(components) =
-        output.pointer("/component-definition/components").and_then(Value::as_array)
-    {
-        for component in components {
-            if let Some(impls) = component.get("control-implementations").and_then(Value::as_array)
-            {
-                for ci in impls {
-                    if let Some(reqs) = ci.get("implemented-requirements").and_then(Value::as_array)
-                    {
-                        for req in reqs {
-                            if let (Some(control_id), Some(uuid)) = (
-                                req.get("control-id").and_then(Value::as_str),
-                                req.get("uuid").and_then(Value::as_str),
-                            ) {
-                                ids.insert(control_id.to_string(), uuid.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    }
-
+fn extract_stable_ids(output: &Value) -> BTreeMap<String, String> {
+    let mut ids = extract_catalog_stable_ids(output);
+    ids.extend(extract_component_stable_ids(output));
     ids
 }
 

--- a/tests/golden_file_tests.rs
+++ b/tests/golden_file_tests.rs
@@ -90,31 +90,30 @@ fn normalize_for_comparison(json: &Value) -> Value {
     normalize_value(json, None)
 }
 
+fn normalize_string_value(s: &str, parent_key: Option<&str>) -> Value {
+    if parent_key == Some("last-modified") {
+        return Value::String(NORMALIZED_TIMESTAMP.to_string());
+    }
+    if UUID_RE.is_match(s) {
+        return Value::String(NORMALIZED_UUID.to_string());
+    }
+    if parent_key == Some("href") {
+        let (path_part, fragment) = match s.find('#') {
+            Some(idx) => (&s[..idx], &s[idx..]),
+            None => (s, ""),
+        };
+        if Path::new(path_part).is_absolute() {
+            return Value::String(format!("{NORMALIZED_PATH}{fragment}"));
+        }
+    }
+    Value::String(s.to_string())
+}
+
 /// Recursively normalize a JSON value, with optional parent key context.
 fn normalize_value(value: &Value, parent_key: Option<&str>) -> Value {
     match value {
-        Value::String(s) => {
-            if parent_key == Some("last-modified") {
-                Value::String(NORMALIZED_TIMESTAMP.to_string())
-            } else if UUID_RE.is_match(s) {
-                Value::String(NORMALIZED_UUID.to_string())
-            } else if parent_key == Some("href") {
-                // Normalize absolute path hrefs (Unix and Windows): keep #fragment, replace path
-                let (path_part, fragment) = match s.find('#') {
-                    Some(idx) => (&s[..idx], &s[idx..]),
-                    None => (s.as_str(), ""),
-                };
-                if Path::new(path_part).is_absolute() {
-                    Value::String(format!("{NORMALIZED_PATH}{fragment}"))
-                } else {
-                    value.clone()
-                }
-            } else {
-                value.clone()
-            }
-        }
+        Value::String(s) => normalize_string_value(s, parent_key),
         Value::Object(map) => {
-            // Check if this is a prop object with name="source-file" — normalize its value
             let is_source_file_prop =
                 map.get("name").and_then(Value::as_str).is_some_and(|n| n == "source-file");
 
@@ -151,53 +150,47 @@ struct AccuracyReport {
     missed_requirements: Vec<String>,
 }
 
+fn extract_catalog_control_ids(json: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    let groups = json.pointer("/catalog/groups").and_then(Value::as_array);
+    for group in groups.into_iter().flatten() {
+        let controls = group.get("controls").and_then(Value::as_array);
+        for control in controls.into_iter().flatten() {
+            if let Some(id) = control.get("id").and_then(Value::as_str) {
+                ids.push(id.to_string());
+            }
+        }
+    }
+    ids
+}
+
+fn extract_component_control_ids(json: &Value) -> Vec<String> {
+    let mut ids = Vec::new();
+    let components = json.pointer("/component-definition/components").and_then(Value::as_array);
+    for component in components.into_iter().flatten() {
+        let impls = component.get("control-implementations").and_then(Value::as_array);
+        for ci in impls.into_iter().flatten() {
+            let reqs = ci.get("implemented-requirements").and_then(Value::as_array);
+            for req in reqs.into_iter().flatten() {
+                if let Some(id) = req.get("control-id").and_then(Value::as_str) {
+                    ids.push(id.to_string());
+                }
+            }
+        }
+    }
+    ids
+}
+
 /// Extract control IDs from an OSCAL JSON value based on strategy.
 ///
 /// - Catalog: `$.catalog.groups[*].controls[*].id`
 /// - Component: `$.component-definition.components[*].control-implementations[*].implemented-requirements[*].control-id`
 fn extract_control_ids(json: &Value, strategy: &str) -> Vec<String> {
-    let mut ids = Vec::new();
     match strategy {
-        "catalog" => {
-            if let Some(groups) = json.pointer("/catalog/groups").and_then(Value::as_array) {
-                for group in groups {
-                    if let Some(controls) = group.get("controls").and_then(Value::as_array) {
-                        for control in controls {
-                            if let Some(id) = control.get("id").and_then(Value::as_str) {
-                                ids.push(id.to_string());
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        "component" => {
-            if let Some(components) =
-                json.pointer("/component-definition/components").and_then(Value::as_array)
-            {
-                for component in components {
-                    if let Some(impls) =
-                        component.get("control-implementations").and_then(Value::as_array)
-                    {
-                        for ci in impls {
-                            if let Some(reqs) =
-                                ci.get("implemented-requirements").and_then(Value::as_array)
-                            {
-                                for req in reqs {
-                                    if let Some(id) = req.get("control-id").and_then(Value::as_str)
-                                    {
-                                        ids.push(id.to_string());
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        _ => {}
+        "catalog" => extract_catalog_control_ids(json),
+        "component" => extract_component_control_ids(json),
+        _ => Vec::new(),
     }
-    ids
 }
 
 /// Measure extraction accuracy by comparing control IDs in expected vs actual.


### PR DESCRIPTION
## Summary

- Extract helper functions from 13 complex functions flagged by SonarQube (rule `rust:S3776`)
- All functions brought below the cognitive complexity threshold of 15
- Also fixes `githubactions:S6573` glob prefix in release workflow

## Files Changed

**Production code (8 functions):**
| File | Function | Complexity Before |
|------|----------|-------------------|
| `round_trip/comparator.rs` | `compare_values` | 26 |
| `round_trip/comparator.rs` | `find_matching_element` | 24 |
| `oscal/back_matter.rs` | `generate_back_matter` | 25 |
| `parse/clauses.rs` | `extract_clauses` | 43 |
| `parse/mod.rs` | `extract_sections` | 21 |
| `trace/formatter.rs` | `format_trace_table` | 24 |
| `parameter/mod.rs` | `extract_section_parameters` | 17 |
| `testing/semantic_eq.rs` | `compare_values` | 22 |

**Test code (5 functions):**
| File | Function | Complexity Before |
|------|----------|-------------------|
| `golden_file_tests.rs` | `extract_control_ids` | 56 |
| `golden_edge_case_tests.rs` | `extract_stable_ids` | 43 |
| `component_pipeline_test.rs` | `control_ids_match_between_catalog_and_component` | 31 |
| `e2e_release_test.rs` | `test_m2_atomize_compound_statements` | 26 |
| `golden_file_tests.rs` | `normalize_value` | 18 |

## Test plan

- [x] All 1020 library tests pass
- [x] All integration/e2e tests pass
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Silent failure audit — no error propagation broken
- [x] No public API changes