### PR TITLE
feat: add stable ID migration analysis

### DIFF
--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -42,7 +42,7 @@ fn reject_output_alias(
         return Ok(());
     };
     let output_identity = path_identity(output, "--output path")?;
-    for (label, input) in [("old policy", old_policy), ("new policy", new_policy)] {
+    for (label, input) in [("old policy path", old_policy), ("new policy path", new_policy)] {
         let input_identity = path_identity(input, label)?;
         if output_identity == input_identity {
             return Err(ForgeError::MigrationError(format!(
@@ -62,7 +62,7 @@ fn path_identity(path: &Path, role: &str) -> Result<PathBuf, ForgeError> {
     let parent =
         path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or(Path::new("."));
     let canonical_parent = parent.canonicalize().map_err(|error| {
-        ForgeError::MigrationError(format!("unable to resolve directory for {role}: {error}"))
+        ForgeError::MigrationError(format!("unable to resolve parent directory of {role}: {error}"))
     })?;
     let file_name = path
         .file_name()
@@ -94,7 +94,7 @@ mod tests {
         std::fs::write(&new, "# New\n").unwrap();
 
         let error = reject_output_alias(Some(&output), &old, &new).unwrap_err().to_string();
-        assert!(error.contains("directory for old policy"), "unexpected error: {error}");
+        assert!(error.contains("parent directory of old policy path"), "unexpected error: {error}");
         assert!(!error.contains("output directory"), "unexpected error: {error}");
     }
 }

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -1,0 +1,87 @@
+use std::path::{Path, PathBuf};
+
+use crate::cli::MigrationOutputFormat;
+use crate::error::ForgeError;
+
+/// Execute a read-only policy migration analysis and emit its complete report.
+///
+/// Returns `true` when the completed report contains any reviewable change.
+/// Analysis failures return before output is written.
+///
+/// # Errors
+///
+/// Returns [`ForgeError::MigrationError`] when an input cannot be analyzed,
+/// the size is invalid, the output aliases an input, or the report cannot be written.
+pub fn execute(
+    old_policy: &Path,
+    new_policy: &Path,
+    format: &MigrationOutputFormat,
+    output: Option<&Path>,
+    max_size_mb: u64,
+) -> Result<bool, ForgeError> {
+    reject_output_alias(output, old_policy, new_policy)?;
+    let max_size_bytes = max_size_mb
+        .checked_mul(1024 * 1024)
+        .ok_or_else(|| ForgeError::MigrationError("--max-size value is too large".to_string()))?;
+    let report = crate::migration::analyze_paths(old_policy, new_policy, max_size_bytes)?;
+    let rendered = match format {
+        MigrationOutputFormat::Text => crate::migration::format_text(&report),
+        MigrationOutputFormat::Json => crate::migration::format_json(&report)?,
+    };
+    crate::cli::output::write_output(&rendered, output)
+        .map_err(|error| ForgeError::MigrationError(error.to_string()))?;
+    Ok(report.has_reviewable_changes())
+}
+
+fn reject_output_alias(
+    output: Option<&Path>,
+    old_policy: &Path,
+    new_policy: &Path,
+) -> Result<(), ForgeError> {
+    let Some(output) = output else {
+        return Ok(());
+    };
+    let output_identity = path_identity(output)?;
+    for (label, input) in [("old policy", old_policy), ("new policy", new_policy)] {
+        let input_identity = path_identity(input)?;
+        if output_identity == input_identity {
+            return Err(ForgeError::MigrationError(format!(
+                "--output must not overwrite the {label}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn path_identity(path: &Path) -> Result<PathBuf, ForgeError> {
+    if path.exists() {
+        return path.canonicalize().map_err(|error| {
+            ForgeError::MigrationError(format!("unable to resolve path: {error}"))
+        });
+    }
+    let parent =
+        path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or(Path::new("."));
+    let canonical_parent = parent.canonicalize().map_err(|error| {
+        ForgeError::MigrationError(format!("unable to resolve output directory: {error}"))
+    })?;
+    let file_name = path
+        .file_name()
+        .ok_or_else(|| ForgeError::MigrationError("--output must name a file".to_string()))?;
+    Ok(canonical_parent.join(file_name))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rejects_output_that_aliases_an_input() {
+        let directory = tempfile::tempdir().unwrap();
+        let old = directory.path().join("old.md");
+        let new = directory.path().join("new.md");
+        std::fs::write(&old, "# Old\n").unwrap();
+        std::fs::write(&new, "# New\n").unwrap();
+        let result = reject_output_alias(Some(&old), &old, &new);
+        assert!(matches!(result, Err(ForgeError::MigrationError(_))));
+    }
+}

--- a/src/cli/migrate.rs
+++ b/src/cli/migrate.rs
@@ -41,9 +41,9 @@ fn reject_output_alias(
     let Some(output) = output else {
         return Ok(());
     };
-    let output_identity = path_identity(output)?;
+    let output_identity = path_identity(output, "--output path")?;
     for (label, input) in [("old policy", old_policy), ("new policy", new_policy)] {
-        let input_identity = path_identity(input)?;
+        let input_identity = path_identity(input, label)?;
         if output_identity == input_identity {
             return Err(ForgeError::MigrationError(format!(
                 "--output must not overwrite the {label}"
@@ -53,20 +53,20 @@ fn reject_output_alias(
     Ok(())
 }
 
-fn path_identity(path: &Path) -> Result<PathBuf, ForgeError> {
+fn path_identity(path: &Path, role: &str) -> Result<PathBuf, ForgeError> {
     if path.exists() {
         return path.canonicalize().map_err(|error| {
-            ForgeError::MigrationError(format!("unable to resolve path: {error}"))
+            ForgeError::MigrationError(format!("unable to resolve {role}: {error}"))
         });
     }
     let parent =
         path.parent().filter(|parent| !parent.as_os_str().is_empty()).unwrap_or(Path::new("."));
     let canonical_parent = parent.canonicalize().map_err(|error| {
-        ForgeError::MigrationError(format!("unable to resolve output directory: {error}"))
+        ForgeError::MigrationError(format!("unable to resolve directory for {role}: {error}"))
     })?;
     let file_name = path
         .file_name()
-        .ok_or_else(|| ForgeError::MigrationError("--output must name a file".to_string()))?;
+        .ok_or_else(|| ForgeError::MigrationError(format!("{role} must name a file")))?;
     Ok(canonical_parent.join(file_name))
 }
 
@@ -83,5 +83,18 @@ mod tests {
         std::fs::write(&new, "# New\n").unwrap();
         let result = reject_output_alias(Some(&old), &old, &new);
         assert!(matches!(result, Err(ForgeError::MigrationError(_))));
+    }
+
+    #[test]
+    fn missing_input_directory_names_the_input_role() {
+        let directory = tempfile::tempdir().unwrap();
+        let old = directory.path().join("missing").join("old.md");
+        let new = directory.path().join("new.md");
+        let output = directory.path().join("report.json");
+        std::fs::write(&new, "# New\n").unwrap();
+
+        let error = reject_output_alias(Some(&output), &old, &new).unwrap_err().to_string();
+        assert!(error.contains("directory for old policy"), "unexpected error: {error}");
+        assert!(!error.contains("output directory"), "unexpected error: {error}");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod diff;
 /// Drift subcommand: content-safe, canonical artifact comparison for CI.
 pub mod drift;
 pub mod export;
+pub mod migrate;
 pub mod output;
 pub mod profile;
 pub mod resolve;
@@ -42,7 +43,7 @@ use crate::config::{self, ConvertCliValues};
     arg_required_else_help = true
 )]
 pub struct Cli {
-    /// The subcommand to execute (convert, export, validate, resolve, diff, drift, trace, profile).
+    /// The subcommand to execute (convert, export, validate, resolve, diff, drift, migrate, trace, profile).
     #[command(subcommand)]
     pub command: Commands,
 
@@ -233,6 +234,31 @@ pub enum Commands {
         format: DriftOutputFormat,
     },
 
+    /// Analyze stable-ID migration between two source-policy revisions
+    Migrate {
+        /// Path to the old policy revision (.md, .markdown, .pdf, or .docx)
+        old_policy: PathBuf,
+
+        /// Path to the new policy revision (.md, .markdown, .pdf, or .docx)
+        new_policy: PathBuf,
+
+        /// Migration report format
+        #[arg(long, value_enum, default_value = "text")]
+        format: MigrationOutputFormat,
+
+        /// Write the completed report to a file instead of stdout
+        #[arg(long)]
+        output: Option<PathBuf>,
+
+        /// Maximum size of each policy input in MB
+        #[arg(
+            long,
+            default_value = "10",
+            value_parser = clap::value_parser!(u64).range(1..=51_200)
+        )]
+        max_size: u64,
+    },
+
     /// Inspect and validate project configuration (.forge.toml)
     Config {
         /// Config subcommands
@@ -299,6 +325,15 @@ pub enum DriftOutputFormat {
     /// Three-line, human-readable status output.
     Text,
     /// Single-object, machine-readable JSON status output.
+    Json,
+}
+
+/// Output format for policy migration reports.
+#[derive(ValueEnum, Clone, Debug, PartialEq, Eq)]
+pub enum MigrationOutputFormat {
+    /// Human-readable audit report.
+    Text,
+    /// Versioned machine-readable report.
     Json,
 }
 
@@ -447,11 +482,26 @@ fn run_drift(
     }
 }
 
+fn run_migrate(
+    old_policy: &Path,
+    new_policy: &Path,
+    format: &MigrationOutputFormat,
+    output: Option<&Path>,
+    max_size: u64,
+) -> Result<(), ForgeError> {
+    if migrate::execute(old_policy, new_policy, format, output, max_size)? {
+        Err(ForgeError::MigrationHasChanges)
+    } else {
+        Ok(())
+    }
+}
+
 /// Execute the CLI command, dispatching to the appropriate subcommand handler.
 ///
 /// # Errors
 ///
 /// Returns `ForgeError` if the subcommand handler fails.
+#[allow(clippy::too_many_lines)] // Flat exhaustive dispatch keeps every clap variant visible here.
 pub fn execute(cli: &Cli) -> Result<(), ForgeError> {
     reject_unsupported_config_selector(cli)?;
     match &cli.command {
@@ -538,6 +588,9 @@ pub fn execute(cli: &Cli) -> Result<(), ForgeError> {
             diff::execute(old_artifact, new_artifact).and_then(|has_changes| {
                 if has_changes { Err(ForgeError::DiffHasChanges) } else { Ok(()) }
             })
+        }
+        Commands::Migrate { old_policy, new_policy, format, output, max_size } => {
+            run_migrate(old_policy, new_policy, format, output.as_deref(), *max_size)
         }
         Commands::Drift { committed_artifact, generated_artifact, format } => {
             run_drift(committed_artifact, generated_artifact, format)

--- a/src/error.rs
+++ b/src/error.rs
@@ -303,6 +303,15 @@ pub enum ForgeError {
     #[error("")]
     DriftDetected,
 
+    /// A completed policy migration analysis found reviewable changes.
+    /// The report is printed separately by the CLI.
+    #[error("")]
+    MigrationHasChanges,
+
+    /// A trustworthy, complete policy migration report could not be produced.
+    #[error("Migration analysis error: {0}")]
+    MigrationError(String),
+
     /// Round-trip validation failed: the re-parsed output does not match the original.
     #[error("Round-trip validation failed: {0} unresolved divergence(s)")]
     RoundTripFailed(usize),
@@ -374,11 +383,13 @@ pub fn exit_code(err: &ForgeError) -> u8 {
         | ForgeError::Serialization(_)
         | ForgeError::DiffHasChanges
         | ForgeError::DriftDetected
+        | ForgeError::MigrationHasChanges
         | ForgeError::RoundTripFailed(_) => 1,
 
         // Exit 2: Parse/Structure errors + usage/required-argument errors
         ForgeError::MissingRequiredArgument(_)
         | ForgeError::DiffError(_)
+        | ForgeError::MigrationError(_)
         | ForgeError::SspBuild(_)
         | ForgeError::NoStructureDetected { .. }
         | ForgeError::Parse(_)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,6 +40,8 @@ pub mod error;
 pub mod export;
 pub mod ingest;
 pub mod io;
+/// Read-only policy revision migration analysis.
+pub mod migration;
 pub mod model;
 pub mod oscal;
 pub mod oscal_cli;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,11 @@ fn main() -> ExitCode {
 
     match cli::execute(&cli) {
         Ok(()) => ExitCode::SUCCESS,
-        Err(ForgeError::DiffHasChanges | ForgeError::DriftDetected) => ExitCode::from(1u8),
+        Err(
+            ForgeError::DiffHasChanges
+            | ForgeError::DriftDetected
+            | ForgeError::MigrationHasChanges,
+        ) => ExitCode::from(1u8),
         Err(e) => {
             eprintln!("Error: {e}");
             ExitCode::from(exit_code(&e))

--- a/src/migration/engine.rs
+++ b/src/migration/engine.rs
@@ -7,11 +7,19 @@ use super::types::{
 };
 use crate::error::ForgeError;
 
+type CandidateGroup = (BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>);
+
 pub(crate) fn classify(
     old: RequirementInventory,
     new: RequirementInventory,
 ) -> Result<MigrationReport, ForgeError> {
-    validate_cross_inventory_ids(&old.requirements, &new.requirements)?;
+    let new_by_id: BTreeMap<&str, usize> = new
+        .requirements
+        .iter()
+        .enumerate()
+        .map(|(index, item)| (item.stable_id.as_str(), index))
+        .collect();
+    validate_cross_inventory_ids(&old.requirements, &new.requirements, &new_by_id)?;
 
     let mut old_matched = vec![false; old.requirements.len()];
     let mut new_matched = vec![false; new.requirements.len()];
@@ -20,6 +28,7 @@ pub(crate) fn classify(
     match_exact_ids(
         &old.requirements,
         &new.requirements,
+        &new_by_id,
         &mut old_matched,
         &mut new_matched,
         &mut entries,
@@ -65,11 +74,11 @@ pub(crate) fn classify(
 fn validate_cross_inventory_ids(
     old: &[InventoryRequirement],
     new: &[InventoryRequirement],
+    new_by_id: &BTreeMap<&str, usize>,
 ) -> Result<(), ForgeError> {
-    let new_by_id: BTreeMap<_, _> = new.iter().map(|item| (&item.stable_id, item)).collect();
     for old_item in old {
-        if let Some(new_item) = new_by_id.get(&old_item.stable_id)
-            && old_item.normalized_text != new_item.normalized_text
+        if let Some(&new_index) = new_by_id.get(old_item.stable_id.as_str())
+            && old_item.normalized_text != new[new_index].normalized_text
         {
             return Err(ForgeError::MigrationError(format!(
                 "stable-ID integrity anomaly for '{}'",
@@ -83,14 +92,13 @@ fn validate_cross_inventory_ids(
 fn match_exact_ids(
     old: &[InventoryRequirement],
     new: &[InventoryRequirement],
+    new_by_id: &BTreeMap<&str, usize>,
     old_matched: &mut [bool],
     new_matched: &mut [bool],
     entries: &mut Vec<MigrationEntry>,
 ) {
-    let new_by_id: BTreeMap<_, _> =
-        new.iter().enumerate().map(|(index, item)| (&item.stable_id, index)).collect();
     for (old_index, old_item) in old.iter().enumerate() {
-        let Some(&new_index) = new_by_id.get(&old_item.stable_id) else {
+        let Some(&new_index) = new_by_id.get(old_item.stable_id.as_str()) else {
             continue;
         };
         old_matched[old_index] = true;
@@ -186,7 +194,7 @@ fn group_ambiguities(
     new_matched: &mut [bool],
     entries: &mut Vec<MigrationEntry>,
 ) {
-    let mut groups: Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)> = Vec::new();
+    let mut groups: Vec<CandidateGroup> = Vec::new();
     append_candidate_groups(
         &mut groups,
         group_unmatched_by(old, old_matched, |item| item.normalized_text.clone()),
@@ -200,24 +208,7 @@ fn group_ambiguities(
         EvidenceCode::CompetingLocator,
     );
 
-    let mut merged: Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)> = Vec::new();
-    for mut group in groups {
-        let mut index = 0;
-        while index < merged.len() {
-            if !group.0.is_disjoint(&merged[index].0) || !group.1.is_disjoint(&merged[index].1) {
-                let other = merged.remove(index);
-                group.0.extend(other.0);
-                group.1.extend(other.1);
-                group.2.extend(other.2);
-                index = 0;
-            } else {
-                index += 1;
-            }
-        }
-        merged.push(group);
-    }
-
-    for (old_indexes, new_indexes, evidence) in merged {
+    for (old_indexes, new_indexes, evidence) in merge_candidate_groups(groups) {
         for &index in &old_indexes {
             old_matched[index] = true;
         }
@@ -236,7 +227,7 @@ fn group_ambiguities(
 }
 
 fn append_candidate_groups<K: Ord>(
-    output: &mut Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)>,
+    output: &mut Vec<CandidateGroup>,
     old_groups: BTreeMap<K, Vec<usize>>,
     new_groups: &BTreeMap<K, Vec<usize>>,
     evidence: EvidenceCode,
@@ -256,6 +247,75 @@ fn append_candidate_groups<K: Ord>(
     }
 }
 
+fn merge_candidate_groups(groups: Vec<CandidateGroup>) -> Vec<CandidateGroup> {
+    let mut components = DisjointSet::new(groups.len());
+    let mut old_owner = BTreeMap::new();
+    let mut new_owner = BTreeMap::new();
+
+    for (group_index, (old_indexes, new_indexes, _)) in groups.iter().enumerate() {
+        for &old_index in old_indexes {
+            if let Some(previous_group) = old_owner.insert(old_index, group_index) {
+                components.union(group_index, previous_group);
+            }
+        }
+        for &new_index in new_indexes {
+            if let Some(previous_group) = new_owner.insert(new_index, group_index) {
+                components.union(group_index, previous_group);
+            }
+        }
+    }
+
+    let mut merged: BTreeMap<usize, CandidateGroup> = BTreeMap::new();
+    for (group_index, (old_indexes, new_indexes, evidence)) in groups.into_iter().enumerate() {
+        let root = components.find(group_index);
+        let component = merged.entry(root).or_default();
+        component.0.extend(old_indexes);
+        component.1.extend(new_indexes);
+        component.2.extend(evidence);
+    }
+    merged.into_values().collect()
+}
+
+struct DisjointSet {
+    parents: Vec<usize>,
+    ranks: Vec<u8>,
+}
+
+impl DisjointSet {
+    fn new(len: usize) -> Self {
+        Self { parents: (0..len).collect(), ranks: vec![0; len] }
+    }
+
+    fn find(&mut self, mut index: usize) -> usize {
+        let mut root = index;
+        while self.parents[root] != root {
+            root = self.parents[root];
+        }
+        while self.parents[index] != index {
+            let parent = self.parents[index];
+            self.parents[index] = root;
+            index = parent;
+        }
+        root
+    }
+
+    fn union(&mut self, left: usize, right: usize) {
+        let left_root = self.find(left);
+        let right_root = self.find(right);
+        if left_root == right_root {
+            return;
+        }
+        match self.ranks[left_root].cmp(&self.ranks[right_root]) {
+            std::cmp::Ordering::Less => self.parents[left_root] = right_root,
+            std::cmp::Ordering::Greater => self.parents[right_root] = left_root,
+            std::cmp::Ordering::Equal => {
+                self.parents[right_root] = left_root;
+                self.ranks[left_root] += 1;
+            }
+        }
+    }
+}
+
 fn add_unmatched(
     old: &[InventoryRequirement],
     new: &[InventoryRequirement],
@@ -263,8 +323,9 @@ fn add_unmatched(
     new_matched: &[bool],
     entries: &mut Vec<MigrationEntry>,
 ) {
-    for (index, item) in old.iter().enumerate().filter(|(index, _)| !old_matched[*index]) {
-        let _ = index;
+    for item in
+        old.iter().enumerate().filter(|(index, _)| !old_matched[*index]).map(|(_, item)| item)
+    {
         entries.push(entry(
             Classification::Retired,
             Vec::new(),
@@ -274,8 +335,9 @@ fn add_unmatched(
             Vec::new(),
         ));
     }
-    for (index, item) in new.iter().enumerate().filter(|(index, _)| !new_matched[*index]) {
-        let _ = index;
+    for item in
+        new.iter().enumerate().filter(|(index, _)| !new_matched[*index]).map(|(_, item)| item)
+    {
         entries.push(entry(
             Classification::Added,
             Vec::new(),
@@ -516,5 +578,37 @@ mod tests {
         let requirements = vec![item("same", "same", "A", 1, 0)];
         let report = classify(inventory(requirements.clone()), inventory(requirements)).unwrap();
         assert!(!report.has_reviewable_changes());
+    }
+
+    #[test]
+    fn ambiguity_groups_merge_transitively() {
+        let groups = vec![
+            (
+                BTreeSet::from([0]),
+                BTreeSet::from([0]),
+                BTreeSet::from([EvidenceCode::DuplicateNormalizedText]),
+            ),
+            (
+                BTreeSet::from([1]),
+                BTreeSet::from([0]),
+                BTreeSet::from([EvidenceCode::CompetingLocator]),
+            ),
+            (
+                BTreeSet::from([1]),
+                BTreeSet::from([2]),
+                BTreeSet::from([EvidenceCode::DuplicateNormalizedText]),
+            ),
+        ];
+
+        let merged = merge_candidate_groups(groups);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].0, BTreeSet::from([0, 1]));
+        assert_eq!(merged[0].1, BTreeSet::from([0, 2]));
+        assert_eq!(
+            merged[0].2,
+            BTreeSet::from(
+                [EvidenceCode::DuplicateNormalizedText, EvidenceCode::CompetingLocator,]
+            )
+        );
     }
 }

--- a/src/migration/engine.rs
+++ b/src/migration/engine.rs
@@ -1,0 +1,520 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use super::types::{
+    ApprovalStatus, Classification, ConfidenceBasis, EvidenceCode, InventoryRequirement,
+    MIGRATION_REPORT_SCHEMA_VERSION, MigrationEntry, MigrationOutcomeCounts, MigrationReport,
+    MigrationSummary, RequirementInventory, RequirementLocation,
+};
+use crate::error::ForgeError;
+
+pub(crate) fn classify(
+    old: RequirementInventory,
+    new: RequirementInventory,
+) -> Result<MigrationReport, ForgeError> {
+    validate_cross_inventory_ids(&old.requirements, &new.requirements)?;
+
+    let mut old_matched = vec![false; old.requirements.len()];
+    let mut new_matched = vec![false; new.requirements.len()];
+    let mut entries = Vec::new();
+
+    match_exact_ids(
+        &old.requirements,
+        &new.requirements,
+        &mut old_matched,
+        &mut new_matched,
+        &mut entries,
+    );
+    match_unique_normalized_text(
+        &old.requirements,
+        &new.requirements,
+        &mut old_matched,
+        &mut new_matched,
+        &mut entries,
+    );
+    match_unique_locators(
+        &old.requirements,
+        &new.requirements,
+        &mut old_matched,
+        &mut new_matched,
+        &mut entries,
+    );
+    group_ambiguities(
+        &old.requirements,
+        &new.requirements,
+        &mut old_matched,
+        &mut new_matched,
+        &mut entries,
+    );
+    add_unmatched(&old.requirements, &new.requirements, &old_matched, &new_matched, &mut entries);
+
+    sort_entries(&mut entries);
+    let summary = summarize(old.requirements.len(), new.requirements.len(), &entries);
+    validate_reconciliation(&old.requirements, &new.requirements, &entries, &summary)?;
+
+    Ok(MigrationReport {
+        schema_version: MIGRATION_REPORT_SCHEMA_VERSION,
+        forge_version: env!("CARGO_PKG_VERSION"),
+        analysis_complete: true,
+        old_source: old.source,
+        new_source: new.source,
+        summary,
+        entries,
+    })
+}
+
+fn validate_cross_inventory_ids(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+) -> Result<(), ForgeError> {
+    let new_by_id: BTreeMap<_, _> = new.iter().map(|item| (&item.stable_id, item)).collect();
+    for old_item in old {
+        if let Some(new_item) = new_by_id.get(&old_item.stable_id)
+            && old_item.normalized_text != new_item.normalized_text
+        {
+            return Err(ForgeError::MigrationError(format!(
+                "stable-ID integrity anomaly for '{}'",
+                old_item.stable_id
+            )));
+        }
+    }
+    Ok(())
+}
+
+fn match_exact_ids(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    old_matched: &mut [bool],
+    new_matched: &mut [bool],
+    entries: &mut Vec<MigrationEntry>,
+) {
+    let new_by_id: BTreeMap<_, _> =
+        new.iter().enumerate().map(|(index, item)| (&item.stable_id, index)).collect();
+    for (old_index, old_item) in old.iter().enumerate() {
+        let Some(&new_index) = new_by_id.get(&old_item.stable_id) else {
+            continue;
+        };
+        old_matched[old_index] = true;
+        new_matched[new_index] = true;
+        let mut evidence = vec![EvidenceCode::ExactId];
+        evidence.extend(location_changes(&old_item.location, &new[new_index].location));
+        evidence.sort_unstable();
+        evidence.dedup();
+        entries.push(entry(
+            Classification::Unchanged,
+            evidence,
+            ConfidenceBasis::Exact,
+            ApprovalStatus::NotRequired,
+            vec![old_item.clone()],
+            vec![new[new_index].clone()],
+        ));
+    }
+}
+
+fn match_unique_normalized_text(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    old_matched: &mut [bool],
+    new_matched: &mut [bool],
+    entries: &mut Vec<MigrationEntry>,
+) {
+    let old_groups = group_unmatched_by(old, old_matched, |item| item.normalized_text.clone());
+    let new_groups = group_unmatched_by(new, new_matched, |item| item.normalized_text.clone());
+    for (normalized, old_indexes) in old_groups {
+        let Some(new_indexes) = new_groups.get(&normalized) else {
+            continue;
+        };
+        if old_indexes.len() != 1 || new_indexes.len() != 1 {
+            continue;
+        }
+        let old_index = old_indexes[0];
+        let new_index = new_indexes[0];
+        old_matched[old_index] = true;
+        new_matched[new_index] = true;
+        let mut evidence = vec![EvidenceCode::UniqueNormalizedText];
+        evidence.extend(location_changes(&old[old_index].location, &new[new_index].location));
+        evidence.sort_unstable();
+        evidence.dedup();
+        entries.push(entry(
+            Classification::ObservedIdChange,
+            evidence,
+            ConfidenceBasis::Exact,
+            ApprovalStatus::NotApproved,
+            vec![old[old_index].clone()],
+            vec![new[new_index].clone()],
+        ));
+    }
+}
+
+fn match_unique_locators(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    old_matched: &mut [bool],
+    new_matched: &mut [bool],
+    entries: &mut Vec<MigrationEntry>,
+) {
+    let old_groups = group_unmatched_by(old, old_matched, locator_key);
+    let new_groups = group_unmatched_by(new, new_matched, locator_key);
+    for (locator, old_indexes) in old_groups {
+        let Some(new_indexes) = new_groups.get(&locator) else {
+            continue;
+        };
+        if old_indexes.len() != 1 || new_indexes.len() != 1 {
+            continue;
+        }
+        let old_index = old_indexes[0];
+        let new_index = new_indexes[0];
+        if old[old_index].normalized_text == new[new_index].normalized_text {
+            continue;
+        }
+        old_matched[old_index] = true;
+        new_matched[new_index] = true;
+        entries.push(entry(
+            Classification::SubstantiveChangeCandidate,
+            vec![EvidenceCode::SameLocator],
+            ConfidenceBasis::Candidate,
+            ApprovalStatus::NotApproved,
+            vec![old[old_index].clone()],
+            vec![new[new_index].clone()],
+        ));
+    }
+}
+
+fn group_ambiguities(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    old_matched: &mut [bool],
+    new_matched: &mut [bool],
+    entries: &mut Vec<MigrationEntry>,
+) {
+    let mut groups: Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)> = Vec::new();
+    append_candidate_groups(
+        &mut groups,
+        group_unmatched_by(old, old_matched, |item| item.normalized_text.clone()),
+        &group_unmatched_by(new, new_matched, |item| item.normalized_text.clone()),
+        EvidenceCode::DuplicateNormalizedText,
+    );
+    append_candidate_groups(
+        &mut groups,
+        group_unmatched_by(old, old_matched, locator_key),
+        &group_unmatched_by(new, new_matched, locator_key),
+        EvidenceCode::CompetingLocator,
+    );
+
+    let mut merged: Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)> = Vec::new();
+    for mut group in groups {
+        let mut index = 0;
+        while index < merged.len() {
+            if !group.0.is_disjoint(&merged[index].0) || !group.1.is_disjoint(&merged[index].1) {
+                let other = merged.remove(index);
+                group.0.extend(other.0);
+                group.1.extend(other.1);
+                group.2.extend(other.2);
+                index = 0;
+            } else {
+                index += 1;
+            }
+        }
+        merged.push(group);
+    }
+
+    for (old_indexes, new_indexes, evidence) in merged {
+        for &index in &old_indexes {
+            old_matched[index] = true;
+        }
+        for &index in &new_indexes {
+            new_matched[index] = true;
+        }
+        entries.push(entry(
+            Classification::Ambiguous,
+            evidence.into_iter().collect(),
+            ConfidenceBasis::Unresolved,
+            ApprovalStatus::NotApproved,
+            old_indexes.into_iter().map(|index| old[index].clone()).collect(),
+            new_indexes.into_iter().map(|index| new[index].clone()).collect(),
+        ));
+    }
+}
+
+fn append_candidate_groups<K: Ord>(
+    output: &mut Vec<(BTreeSet<usize>, BTreeSet<usize>, BTreeSet<EvidenceCode>)>,
+    old_groups: BTreeMap<K, Vec<usize>>,
+    new_groups: &BTreeMap<K, Vec<usize>>,
+    evidence: EvidenceCode,
+) {
+    for (key, old_indexes) in old_groups {
+        let Some(new_indexes) = new_groups.get(&key) else {
+            continue;
+        };
+        if old_indexes.len() == 1 && new_indexes.len() == 1 {
+            continue;
+        }
+        output.push((
+            old_indexes.into_iter().collect(),
+            new_indexes.iter().copied().collect(),
+            BTreeSet::from([evidence]),
+        ));
+    }
+}
+
+fn add_unmatched(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    old_matched: &[bool],
+    new_matched: &[bool],
+    entries: &mut Vec<MigrationEntry>,
+) {
+    for (index, item) in old.iter().enumerate().filter(|(index, _)| !old_matched[*index]) {
+        let _ = index;
+        entries.push(entry(
+            Classification::Retired,
+            Vec::new(),
+            ConfidenceBasis::Unmatched,
+            ApprovalStatus::NotRequired,
+            vec![item.clone()],
+            Vec::new(),
+        ));
+    }
+    for (index, item) in new.iter().enumerate().filter(|(index, _)| !new_matched[*index]) {
+        let _ = index;
+        entries.push(entry(
+            Classification::Added,
+            Vec::new(),
+            ConfidenceBasis::Unmatched,
+            ApprovalStatus::NotRequired,
+            Vec::new(),
+            vec![item.clone()],
+        ));
+    }
+}
+
+fn group_unmatched_by<K: Ord>(
+    items: &[InventoryRequirement],
+    matched: &[bool],
+    key: impl Fn(&InventoryRequirement) -> K,
+) -> BTreeMap<K, Vec<usize>> {
+    let mut groups = BTreeMap::new();
+    for (index, item) in items.iter().enumerate().filter(|(index, _)| !matched[*index]) {
+        groups.entry(key(item)).or_insert_with(Vec::new).push(index);
+    }
+    groups
+}
+
+fn locator_key(item: &InventoryRequirement) -> (String, usize, usize) {
+    (item.location.section_path.clone(), item.location.line, item.location.atom_index)
+}
+
+fn location_changes(old: &RequirementLocation, new: &RequirementLocation) -> Vec<EvidenceCode> {
+    let mut changes = Vec::new();
+    if old.file_label != new.file_label {
+        changes.push(EvidenceCode::SourceFileChanged);
+    }
+    if old.section_path != new.section_path {
+        changes.push(EvidenceCode::SectionPathChanged);
+    }
+    if old.line != new.line {
+        changes.push(EvidenceCode::SourceLineChanged);
+    }
+    if old.atom_index != new.atom_index {
+        changes.push(EvidenceCode::AtomIndexChanged);
+    }
+    changes
+}
+
+fn entry(
+    classification: Classification,
+    evidence: Vec<EvidenceCode>,
+    confidence_basis: ConfidenceBasis,
+    approval_status: ApprovalStatus,
+    mut old: Vec<InventoryRequirement>,
+    mut new: Vec<InventoryRequirement>,
+) -> MigrationEntry {
+    old.sort_by(|left, right| left.stable_id.cmp(&right.stable_id));
+    new.sort_by(|left, right| left.stable_id.cmp(&right.stable_id));
+    MigrationEntry { classification, evidence, confidence_basis, approval_status, old, new }
+}
+
+fn sort_entries(entries: &mut [MigrationEntry]) {
+    entries.sort_by(|left, right| {
+        left.classification
+            .rank()
+            .cmp(&right.classification.rank())
+            .then_with(|| first_id(&left.old).cmp(first_id(&right.old)))
+            .then_with(|| first_id(&left.new).cmp(first_id(&right.new)))
+    });
+}
+
+fn first_id(items: &[InventoryRequirement]) -> &str {
+    items.first().map_or("", |item| item.stable_id.as_str())
+}
+
+fn summarize(total_old: usize, total_new: usize, entries: &[MigrationEntry]) -> MigrationSummary {
+    let count = |classification| {
+        entries.iter().filter(|entry| entry.classification == classification).count()
+    };
+    MigrationSummary {
+        total_old,
+        total_new,
+        unchanged: count(Classification::Unchanged),
+        observed_id_changes: count(Classification::ObservedIdChange),
+        substantive_change_candidates: count(Classification::SubstantiveChangeCandidate),
+        atomization_change_candidates: count(Classification::AtomizationChangeCandidate),
+        ambiguity_groups: count(Classification::Ambiguous),
+        retired: count(Classification::Retired),
+        added: count(Classification::Added),
+        old_requirements: outcome_counts(entries, |entry| entry.old.len()),
+        new_requirements: outcome_counts(entries, |entry| entry.new.len()),
+    }
+}
+
+fn outcome_counts(
+    entries: &[MigrationEntry],
+    side_len: impl Fn(&MigrationEntry) -> usize,
+) -> MigrationOutcomeCounts {
+    let mut counts = MigrationOutcomeCounts::default();
+    for entry in entries {
+        let requirement_count = side_len(entry);
+        match entry.classification {
+            Classification::Unchanged => counts.unchanged += requirement_count,
+            Classification::ObservedIdChange => {
+                counts.observed_id_changes += requirement_count;
+            }
+            Classification::SubstantiveChangeCandidate => {
+                counts.substantive_change_candidates += requirement_count;
+            }
+            Classification::AtomizationChangeCandidate => {
+                counts.atomization_change_candidates += requirement_count;
+            }
+            Classification::Ambiguous => counts.ambiguous += requirement_count,
+            Classification::Retired => counts.retired += requirement_count,
+            Classification::Added => counts.added += requirement_count,
+        }
+    }
+    counts
+}
+
+fn validate_reconciliation(
+    old: &[InventoryRequirement],
+    new: &[InventoryRequirement],
+    entries: &[MigrationEntry],
+    summary: &MigrationSummary,
+) -> Result<(), ForgeError> {
+    let expected_old: BTreeSet<_> = old.iter().map(|item| item.stable_id.as_str()).collect();
+    let expected_new: BTreeSet<_> = new.iter().map(|item| item.stable_id.as_str()).collect();
+    let actual_old: Vec<_> = entries
+        .iter()
+        .flat_map(|entry| entry.old.iter().map(|item| item.stable_id.as_str()))
+        .collect();
+    let actual_new: Vec<_> = entries
+        .iter()
+        .flat_map(|entry| entry.new.iter().map(|item| item.stable_id.as_str()))
+        .collect();
+    let actual_old_set: BTreeSet<_> = actual_old.iter().copied().collect();
+    let actual_new_set: BTreeSet<_> = actual_new.iter().copied().collect();
+    if actual_old.len() != actual_old_set.len()
+        || actual_new.len() != actual_new_set.len()
+        || actual_old_set != expected_old
+        || actual_new_set != expected_new
+        || summary.old_requirements.total() != summary.total_old
+        || summary.new_requirements.total() != summary.total_new
+    {
+        return Err(ForgeError::MigrationError(
+            "internal reconciliation invariant failed".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::types::{InputFormat, LocationBasis, SourceProvenance};
+
+    fn item(id: &str, text: &str, section: &str, line: usize, atom: usize) -> InventoryRequirement {
+        InventoryRequirement {
+            stable_id: id.to_string(),
+            normalized_text_sha256: format!("hash-{text}"),
+            normalized_text: text.to_string(),
+            location: RequirementLocation {
+                file_label: "policy.md".to_string(),
+                section_path: section.to_string(),
+                section_title: section.to_string(),
+                line,
+                line_basis: LocationBasis::SourceLine,
+                atom_index: atom,
+            },
+        }
+    }
+
+    fn inventory(items: Vec<InventoryRequirement>) -> RequirementInventory {
+        RequirementInventory {
+            source: SourceProvenance {
+                label: "policy.md".to_string(),
+                format: InputFormat::Markdown,
+                sha256: "source-hash".to_string(),
+                location_basis: LocationBasis::SourceLine,
+            },
+            requirements: items,
+        }
+    }
+
+    #[test]
+    fn classifies_exact_moved_edited_retired_and_added() {
+        let old = inventory(vec![
+            item("same", "same", "A", 1, 0),
+            item("old-moved", "moved", "A", 2, 0),
+            item("old-edited", "old prose", "A", 3, 0),
+            item("retired", "retired", "A", 4, 0),
+        ]);
+        let new = inventory(vec![
+            item("same", "same", "A", 1, 0),
+            item("new-moved", "moved", "B", 20, 0),
+            item("new-edited", "new prose", "A", 3, 0),
+            item("added", "added", "A", 5, 0),
+        ]);
+
+        let report = classify(old, new).unwrap();
+        assert_eq!(report.summary.unchanged, 1);
+        assert_eq!(report.summary.observed_id_changes, 1);
+        assert_eq!(report.summary.substantive_change_candidates, 1);
+        assert_eq!(report.summary.retired, 1);
+        assert_eq!(report.summary.added, 1);
+        assert!(report.has_reviewable_changes());
+    }
+
+    #[test]
+    fn duplicate_prose_is_one_deterministic_ambiguity_group() {
+        let old = inventory(vec![
+            item("old-a", "duplicate", "A", 1, 0),
+            item("old-b", "duplicate", "B", 2, 0),
+        ]);
+        let new = inventory(vec![
+            item("new-a", "duplicate", "C", 3, 0),
+            item("new-b", "duplicate", "D", 4, 0),
+        ]);
+
+        let report = classify(old, new).unwrap();
+        assert_eq!(report.summary.ambiguity_groups, 1);
+        assert_eq!(report.summary.old_requirements.ambiguous, 2);
+        assert_eq!(report.summary.new_requirements.ambiguous, 2);
+        assert_eq!(report.summary.old_requirements.total(), report.summary.total_old);
+        assert_eq!(report.summary.new_requirements.total(), report.summary.total_new);
+        assert_eq!(report.entries[0].old.len(), 2);
+        assert_eq!(report.entries[0].new.len(), 2);
+    }
+
+    #[test]
+    fn differing_text_for_same_id_is_integrity_error() {
+        let result = classify(
+            inventory(vec![item("collision", "old", "A", 1, 0)]),
+            inventory(vec![item("collision", "new", "A", 1, 0)]),
+        );
+        assert!(matches!(result, Err(ForgeError::MigrationError(_))));
+    }
+
+    #[test]
+    fn identical_inventories_are_clean() {
+        let requirements = vec![item("same", "same", "A", 1, 0)];
+        let report = classify(inventory(requirements.clone()), inventory(requirements)).unwrap();
+        assert!(!report.has_reviewable_changes());
+    }
+}

--- a/src/migration/formatter.rs
+++ b/src/migration/formatter.rs
@@ -24,14 +24,14 @@ pub fn format_text(report: &MigrationReport) -> String {
         output,
         "old: {} [{}; sha256={}]",
         escape_controls(&report.old_source.label),
-        format_name(report.old_source.format),
+        report.old_source.format.as_str(),
         report.old_source.sha256
     );
     let _ = writeln!(
         output,
         "new: {} [{}; sha256={}]",
         escape_controls(&report.new_source.label),
-        format_name(report.new_source.format),
+        report.new_source.format.as_str(),
         report.new_source.sha256
     );
     if report.old_source.location_basis != super::types::LocationBasis::SourceLine
@@ -60,19 +60,15 @@ pub fn format_text(report: &MigrationReport) -> String {
     write_outcome_counts(&mut output, "new outcomes", &summary.new_requirements);
 
     for entry in &report.entries {
-        let _ = writeln!(output, "\n{}", classification_name(entry.classification));
-        let evidence = entry
-            .evidence
-            .iter()
-            .map(|evidence| evidence_name(*evidence))
-            .collect::<Vec<_>>()
-            .join(",");
+        let _ = writeln!(output, "\n{}", entry.classification.as_str());
+        let evidence =
+            entry.evidence.iter().map(|evidence| evidence.as_str()).collect::<Vec<_>>().join(",");
         let _ = writeln!(output, "  evidence: {evidence}");
         let _ = writeln!(
             output,
             "  confidence: {}; approval: {}",
-            confidence_name(entry.confidence_basis),
-            approval_name(entry.approval_status)
+            entry.confidence_basis.as_str(),
+            entry.approval_status.as_str()
         );
         for item in &entry.old {
             write_item(&mut output, "old", item);
@@ -103,51 +99,6 @@ fn write_outcome_counts(
     );
 }
 
-const fn classification_name(classification: super::types::Classification) -> &'static str {
-    use super::types::Classification;
-    match classification {
-        Classification::Unchanged => "unchanged",
-        Classification::ObservedIdChange => "observed_id_change",
-        Classification::SubstantiveChangeCandidate => "substantive_change_candidate",
-        Classification::AtomizationChangeCandidate => "atomization_change_candidate",
-        Classification::Ambiguous => "ambiguous",
-        Classification::Retired => "retired",
-        Classification::Added => "added",
-    }
-}
-
-const fn evidence_name(evidence: super::types::EvidenceCode) -> &'static str {
-    use super::types::EvidenceCode;
-    match evidence {
-        EvidenceCode::ExactId => "exact_id",
-        EvidenceCode::UniqueNormalizedText => "unique_normalized_text",
-        EvidenceCode::SameLocator => "same_locator",
-        EvidenceCode::DuplicateNormalizedText => "duplicate_normalized_text",
-        EvidenceCode::CompetingLocator => "competing_locator",
-        EvidenceCode::SourceFileChanged => "source_file_changed",
-        EvidenceCode::SectionPathChanged => "section_path_changed",
-        EvidenceCode::SourceLineChanged => "source_line_changed",
-        EvidenceCode::AtomIndexChanged => "atom_index_changed",
-    }
-}
-
-const fn confidence_name(confidence: super::types::ConfidenceBasis) -> &'static str {
-    use super::types::ConfidenceBasis;
-    match confidence {
-        ConfidenceBasis::Exact => "exact",
-        ConfidenceBasis::Candidate => "candidate",
-        ConfidenceBasis::Unresolved => "unresolved",
-        ConfidenceBasis::Unmatched => "unmatched",
-    }
-}
-
-const fn approval_name(approval: super::types::ApprovalStatus) -> &'static str {
-    match approval {
-        super::types::ApprovalStatus::NotRequired => "not_required",
-        super::types::ApprovalStatus::NotApproved => "not_approved",
-    }
-}
-
 fn write_item(output: &mut String, side: &str, item: &InventoryRequirement) {
     let _ = writeln!(
         output,
@@ -159,14 +110,6 @@ fn write_item(output: &mut String, side: &str, item: &InventoryRequirement) {
         item.location.atom_index,
         escape_controls(&item.location.section_path)
     );
-}
-
-const fn format_name(format: super::types::InputFormat) -> &'static str {
-    match format {
-        super::types::InputFormat::Markdown => "markdown",
-        super::types::InputFormat::Pdf => "pdf",
-        super::types::InputFormat::Docx => "docx",
-    }
 }
 
 fn escape_controls(value: &str) -> String {

--- a/src/migration/formatter.rs
+++ b/src/migration/formatter.rs
@@ -1,0 +1,193 @@
+use std::fmt::Write;
+
+use super::types::{InventoryRequirement, MigrationReport};
+use crate::error::ForgeError;
+
+/// Serialize a migration report using the versioned JSON contract.
+///
+/// # Errors
+///
+/// Returns [`ForgeError::MigrationError`] if serialization fails.
+pub fn format_json(report: &MigrationReport) -> Result<String, ForgeError> {
+    let mut output = serde_json::to_string_pretty(report).map_err(|error| {
+        ForgeError::MigrationError(format!("unable to serialize report: {error}"))
+    })?;
+    output.push('\n');
+    Ok(output)
+}
+
+#[must_use]
+pub fn format_text(report: &MigrationReport) -> String {
+    let mut output = String::new();
+    let _ = writeln!(output, "FORGE policy migration report");
+    let _ = writeln!(
+        output,
+        "old: {} [{}; sha256={}]",
+        escape_controls(&report.old_source.label),
+        format_name(report.old_source.format),
+        report.old_source.sha256
+    );
+    let _ = writeln!(
+        output,
+        "new: {} [{}; sha256={}]",
+        escape_controls(&report.new_source.label),
+        format_name(report.new_source.format),
+        report.new_source.sha256
+    );
+    if report.old_source.location_basis != super::types::LocationBasis::SourceLine
+        || report.new_source.location_basis != super::types::LocationBasis::SourceLine
+    {
+        let _ = writeln!(
+            output,
+            "note: PDF/DOCX lines are normalized extracted-text lines, not native page or paragraph coordinates"
+        );
+    }
+    let summary = &report.summary;
+    let _ = writeln!(
+        output,
+        "summary: old={} new={} unchanged-entries={} observed-id-change-entries={} substantive-candidate-entries={} atomization-candidate-entries={} ambiguity-groups={} retired-entries={} added-entries={}",
+        summary.total_old,
+        summary.total_new,
+        summary.unchanged,
+        summary.observed_id_changes,
+        summary.substantive_change_candidates,
+        summary.atomization_change_candidates,
+        summary.ambiguity_groups,
+        summary.retired,
+        summary.added
+    );
+    write_outcome_counts(&mut output, "old outcomes", &summary.old_requirements);
+    write_outcome_counts(&mut output, "new outcomes", &summary.new_requirements);
+
+    for entry in &report.entries {
+        let _ = writeln!(output, "\n{}", classification_name(entry.classification));
+        let evidence = entry
+            .evidence
+            .iter()
+            .map(|evidence| evidence_name(*evidence))
+            .collect::<Vec<_>>()
+            .join(",");
+        let _ = writeln!(output, "  evidence: {evidence}");
+        let _ = writeln!(
+            output,
+            "  confidence: {}; approval: {}",
+            confidence_name(entry.confidence_basis),
+            approval_name(entry.approval_status)
+        );
+        for item in &entry.old {
+            write_item(&mut output, "old", item);
+        }
+        for item in &entry.new {
+            write_item(&mut output, "new", item);
+        }
+    }
+    output
+}
+
+fn write_outcome_counts(
+    output: &mut String,
+    label: &str,
+    counts: &super::types::MigrationOutcomeCounts,
+) {
+    let _ = writeln!(
+        output,
+        "{label}: unchanged={} observed-id-change={} substantive-candidate={} atomization-candidate={} ambiguous={} retired={} added={} total={}",
+        counts.unchanged,
+        counts.observed_id_changes,
+        counts.substantive_change_candidates,
+        counts.atomization_change_candidates,
+        counts.ambiguous,
+        counts.retired,
+        counts.added,
+        counts.total()
+    );
+}
+
+const fn classification_name(classification: super::types::Classification) -> &'static str {
+    use super::types::Classification;
+    match classification {
+        Classification::Unchanged => "unchanged",
+        Classification::ObservedIdChange => "observed_id_change",
+        Classification::SubstantiveChangeCandidate => "substantive_change_candidate",
+        Classification::AtomizationChangeCandidate => "atomization_change_candidate",
+        Classification::Ambiguous => "ambiguous",
+        Classification::Retired => "retired",
+        Classification::Added => "added",
+    }
+}
+
+const fn evidence_name(evidence: super::types::EvidenceCode) -> &'static str {
+    use super::types::EvidenceCode;
+    match evidence {
+        EvidenceCode::ExactId => "exact_id",
+        EvidenceCode::UniqueNormalizedText => "unique_normalized_text",
+        EvidenceCode::SameLocator => "same_locator",
+        EvidenceCode::DuplicateNormalizedText => "duplicate_normalized_text",
+        EvidenceCode::CompetingLocator => "competing_locator",
+        EvidenceCode::SourceFileChanged => "source_file_changed",
+        EvidenceCode::SectionPathChanged => "section_path_changed",
+        EvidenceCode::SourceLineChanged => "source_line_changed",
+        EvidenceCode::AtomIndexChanged => "atom_index_changed",
+    }
+}
+
+const fn confidence_name(confidence: super::types::ConfidenceBasis) -> &'static str {
+    use super::types::ConfidenceBasis;
+    match confidence {
+        ConfidenceBasis::Exact => "exact",
+        ConfidenceBasis::Candidate => "candidate",
+        ConfidenceBasis::Unresolved => "unresolved",
+        ConfidenceBasis::Unmatched => "unmatched",
+    }
+}
+
+const fn approval_name(approval: super::types::ApprovalStatus) -> &'static str {
+    match approval {
+        super::types::ApprovalStatus::NotRequired => "not_required",
+        super::types::ApprovalStatus::NotApproved => "not_approved",
+    }
+}
+
+fn write_item(output: &mut String, side: &str, item: &InventoryRequirement) {
+    let _ = writeln!(
+        output,
+        "  {side}: {} text-sha256={} {}:{} atom={} section={}",
+        item.stable_id,
+        item.normalized_text_sha256,
+        escape_controls(&item.location.file_label),
+        item.location.line,
+        item.location.atom_index,
+        escape_controls(&item.location.section_path)
+    );
+}
+
+const fn format_name(format: super::types::InputFormat) -> &'static str {
+    match format {
+        super::types::InputFormat::Markdown => "markdown",
+        super::types::InputFormat::Pdf => "pdf",
+        super::types::InputFormat::Docx => "docx",
+    }
+}
+
+fn escape_controls(value: &str) -> String {
+    value
+        .chars()
+        .flat_map(|character| {
+            if character.is_control() {
+                character.escape_default().collect::<Vec<_>>()
+            } else {
+                vec![character]
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_controls;
+
+    #[test]
+    fn text_output_escapes_terminal_controls() {
+        assert_eq!(escape_controls("safe\u{1b}[31m"), "safe\\u{1b}[31m");
+    }
+}

--- a/src/migration/inventory.rs
+++ b/src/migration/inventory.rs
@@ -1,0 +1,123 @@
+use std::path::Path;
+
+use sha2::{Digest, Sha256};
+
+use super::types::{
+    InputFormat, InventoryRequirement, LocationBasis, RequirementInventory, RequirementLocation,
+    SourceProvenance,
+};
+use crate::error::ForgeError;
+use crate::model::{PolicyRequirement, PolicySection};
+
+pub(crate) fn build_inventory(
+    path: &Path,
+    max_size_bytes: u64,
+) -> Result<RequirementInventory, ForgeError> {
+    let document = crate::pipeline::prepare_document(path, max_size_bytes)
+        .map_err(|error| ForgeError::MigrationError(error.to_string()))?;
+    let format = input_format(path)?;
+    let location_basis = match format {
+        InputFormat::Markdown => LocationBasis::SourceLine,
+        InputFormat::Pdf | InputFormat::Docx => LocationBasis::NormalizedExtractedTextLine,
+    };
+    let label = path.to_string_lossy().into_owned();
+    let source = SourceProvenance {
+        label: label.clone(),
+        format,
+        sha256: document.metadata.content_hash.ok_or_else(|| {
+            ForgeError::MigrationError(
+                "source fingerprint was not produced by ingestion".to_string(),
+            )
+        })?,
+        location_basis,
+    };
+
+    let mut requirements = Vec::new();
+    for section in &document.sections {
+        collect_section(section, &section.title, &label, location_basis, &mut requirements)?;
+    }
+    requirements.sort_by(|left, right| left.stable_id.cmp(&right.stable_id));
+    validate_unique_ids(&requirements)?;
+    Ok(RequirementInventory { source, requirements })
+}
+
+fn input_format(path: &Path) -> Result<InputFormat, ForgeError> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .unwrap_or_default()
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "md" | "markdown" => Ok(InputFormat::Markdown),
+        "pdf" => Ok(InputFormat::Pdf),
+        "docx" => Ok(InputFormat::Docx),
+        extension => {
+            Err(ForgeError::MigrationError(format!("unsupported policy format '.{extension}'")))
+        }
+    }
+}
+
+fn collect_section(
+    section: &PolicySection,
+    section_path: &str,
+    file_label: &str,
+    location_basis: LocationBasis,
+    output: &mut Vec<InventoryRequirement>,
+) -> Result<(), ForgeError> {
+    for requirement in &section.requirements {
+        output.push(inventory_requirement(
+            requirement,
+            section,
+            section_path,
+            file_label,
+            location_basis,
+        )?);
+    }
+    for child in &section.children {
+        let child_path = format!("{section_path}/{}", child.title);
+        collect_section(child, &child_path, file_label, location_basis, output)?;
+    }
+    Ok(())
+}
+
+fn inventory_requirement(
+    requirement: &PolicyRequirement,
+    section: &PolicySection,
+    section_path: &str,
+    file_label: &str,
+    location_basis: LocationBasis,
+) -> Result<InventoryRequirement, ForgeError> {
+    let stable_id = requirement.stable_id.clone().ok_or_else(|| {
+        ForgeError::MigrationError(
+            "shared pipeline returned a requirement without a stable ID".to_string(),
+        )
+    })?;
+    let normalized_text = crate::uuid::normalize_for_hashing(&requirement.text);
+    let normalized_text_sha256 = format!("{:x}", Sha256::digest(normalized_text.as_bytes()));
+    Ok(InventoryRequirement {
+        stable_id,
+        normalized_text_sha256,
+        normalized_text,
+        location: RequirementLocation {
+            file_label: file_label.to_string(),
+            section_path: section_path.to_string(),
+            section_title: section.title.clone(),
+            line: requirement.source_line,
+            line_basis: location_basis,
+            atom_index: requirement.atom_index,
+        },
+    })
+}
+
+fn validate_unique_ids(requirements: &[InventoryRequirement]) -> Result<(), ForgeError> {
+    for pair in requirements.windows(2) {
+        if pair[0].stable_id == pair[1].stable_id {
+            return Err(ForgeError::MigrationError(format!(
+                "stable-ID integrity anomaly for '{}'",
+                pair[0].stable_id
+            )));
+        }
+    }
+    Ok(())
+}

--- a/src/migration/mod.rs
+++ b/src/migration/mod.rs
@@ -1,0 +1,38 @@
+//! Deterministic, read-only comparison of two source-policy revisions.
+
+mod engine;
+mod formatter;
+mod inventory;
+mod types;
+
+use std::path::Path;
+
+pub use formatter::{format_json, format_text};
+pub use types::{
+    ApprovalStatus, Classification, ConfidenceBasis, EvidenceCode, InputFormat,
+    InventoryRequirement, LocationBasis, MIGRATION_REPORT_SCHEMA_VERSION, MigrationEntry,
+    MigrationOutcomeCounts, MigrationReport, MigrationSummary, RequirementLocation,
+    SourceProvenance,
+};
+
+use crate::error::ForgeError;
+
+/// Analyze two policy files through the shared conversion preparation pipeline.
+///
+/// The function reads but never writes either policy. All analysis failures are
+/// normalized to [`ForgeError::MigrationError`] so CLI callers can honor the
+/// migration command's documented exit-2 contract.
+///
+/// # Errors
+///
+/// Returns [`ForgeError::MigrationError`] when either policy cannot be fully
+/// inventoried or when classification invariants fail.
+pub fn analyze_paths(
+    old_path: &Path,
+    new_path: &Path,
+    max_size_bytes: u64,
+) -> Result<MigrationReport, ForgeError> {
+    let old = inventory::build_inventory(old_path, max_size_bytes)?;
+    let new = inventory::build_inventory(new_path, max_size_bytes)?;
+    engine::classify(old, new)
+}

--- a/src/migration/types.rs
+++ b/src/migration/types.rs
@@ -20,6 +20,17 @@ pub enum InputFormat {
     Docx,
 }
 
+impl InputFormat {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Markdown => "markdown",
+            Self::Pdf => "pdf",
+            Self::Docx => "docx",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum LocationBasis {
@@ -61,6 +72,19 @@ pub enum Classification {
 }
 
 impl Classification {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Unchanged => "unchanged",
+            Self::ObservedIdChange => "observed_id_change",
+            Self::SubstantiveChangeCandidate => "substantive_change_candidate",
+            Self::AtomizationChangeCandidate => "atomization_change_candidate",
+            Self::Ambiguous => "ambiguous",
+            Self::Retired => "retired",
+            Self::Added => "added",
+        }
+    }
+
     pub(crate) const fn rank(self) -> u8 {
         match self {
             Self::Unchanged => 0,
@@ -88,6 +112,23 @@ pub enum EvidenceCode {
     AtomIndexChanged,
 }
 
+impl EvidenceCode {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExactId => "exact_id",
+            Self::UniqueNormalizedText => "unique_normalized_text",
+            Self::SameLocator => "same_locator",
+            Self::DuplicateNormalizedText => "duplicate_normalized_text",
+            Self::CompetingLocator => "competing_locator",
+            Self::SourceFileChanged => "source_file_changed",
+            Self::SectionPathChanged => "section_path_changed",
+            Self::SourceLineChanged => "source_line_changed",
+            Self::AtomIndexChanged => "atom_index_changed",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ConfidenceBasis {
@@ -97,11 +138,33 @@ pub enum ConfidenceBasis {
     Unmatched,
 }
 
+impl ConfidenceBasis {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::Candidate => "candidate",
+            Self::Unresolved => "unresolved",
+            Self::Unmatched => "unmatched",
+        }
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum ApprovalStatus {
     NotRequired,
     NotApproved,
+}
+
+impl ApprovalStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::NotRequired => "not_required",
+            Self::NotApproved => "not_approved",
+        }
+    }
 }
 
 /// A top-level, mutually exclusive migration outcome.
@@ -192,4 +255,60 @@ impl MigrationReport {
 pub(crate) struct RequirementInventory {
     pub source: SourceProvenance,
     pub requirements: Vec<InventoryRequirement>,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde::Serialize;
+
+    use super::*;
+
+    fn assert_json_name<T: Serialize>(value: T, name: &str) {
+        assert_eq!(
+            serde_json::to_value(value).unwrap(),
+            serde_json::Value::String(name.to_string())
+        );
+    }
+
+    #[test]
+    fn canonical_names_match_json_serialization() {
+        for value in [InputFormat::Markdown, InputFormat::Pdf, InputFormat::Docx] {
+            assert_json_name(value, value.as_str());
+        }
+        for value in [
+            Classification::Unchanged,
+            Classification::ObservedIdChange,
+            Classification::SubstantiveChangeCandidate,
+            Classification::AtomizationChangeCandidate,
+            Classification::Ambiguous,
+            Classification::Retired,
+            Classification::Added,
+        ] {
+            assert_json_name(value, value.as_str());
+        }
+        for value in [
+            EvidenceCode::ExactId,
+            EvidenceCode::UniqueNormalizedText,
+            EvidenceCode::SameLocator,
+            EvidenceCode::DuplicateNormalizedText,
+            EvidenceCode::CompetingLocator,
+            EvidenceCode::SourceFileChanged,
+            EvidenceCode::SectionPathChanged,
+            EvidenceCode::SourceLineChanged,
+            EvidenceCode::AtomIndexChanged,
+        ] {
+            assert_json_name(value, value.as_str());
+        }
+        for value in [
+            ConfidenceBasis::Exact,
+            ConfidenceBasis::Candidate,
+            ConfidenceBasis::Unresolved,
+            ConfidenceBasis::Unmatched,
+        ] {
+            assert_json_name(value, value.as_str());
+        }
+        for value in [ApprovalStatus::NotRequired, ApprovalStatus::NotApproved] {
+            assert_json_name(value, value.as_str());
+        }
+    }
 }

--- a/src/migration/types.rs
+++ b/src/migration/types.rs
@@ -234,6 +234,9 @@ pub struct MigrationReport {
 }
 
 impl MigrationReport {
+    /// Whether PRD 53 M-20 requires a review signal. Any source-location
+    /// change is intentionally reviewable, including source-line or atom-index
+    /// drift that does not alter normalized requirement prose.
     #[must_use]
     pub fn has_reviewable_changes(&self) -> bool {
         self.entries.iter().any(|entry| {

--- a/src/migration/types.rs
+++ b/src/migration/types.rs
@@ -1,0 +1,195 @@
+use serde::Serialize;
+
+/// Versioned machine-readable migration report contract.
+pub const MIGRATION_REPORT_SCHEMA_VERSION: &str = "forge.migration-report/1";
+
+/// Raw source-policy provenance included in every report.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct SourceProvenance {
+    pub label: String,
+    pub format: InputFormat,
+    pub sha256: String,
+    pub location_basis: LocationBasis,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum InputFormat {
+    Markdown,
+    Pdf,
+    Docx,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LocationBasis {
+    SourceLine,
+    NormalizedExtractedTextLine,
+}
+
+/// Audit location and stable-ID seed fields for one atomized requirement.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct RequirementLocation {
+    pub file_label: String,
+    pub section_path: String,
+    pub section_title: String,
+    pub line: usize,
+    pub line_basis: LocationBasis,
+    pub atom_index: usize,
+}
+
+/// One requirement in a migration inventory.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct InventoryRequirement {
+    pub stable_id: String,
+    pub normalized_text_sha256: String,
+    pub location: RequirementLocation,
+    #[serde(skip)]
+    pub(crate) normalized_text: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Classification {
+    Unchanged,
+    ObservedIdChange,
+    SubstantiveChangeCandidate,
+    AtomizationChangeCandidate,
+    Ambiguous,
+    Retired,
+    Added,
+}
+
+impl Classification {
+    pub(crate) const fn rank(self) -> u8 {
+        match self {
+            Self::Unchanged => 0,
+            Self::ObservedIdChange => 1,
+            Self::SubstantiveChangeCandidate => 2,
+            Self::AtomizationChangeCandidate => 3,
+            Self::Ambiguous => 4,
+            Self::Retired => 5,
+            Self::Added => 6,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceCode {
+    ExactId,
+    UniqueNormalizedText,
+    SameLocator,
+    DuplicateNormalizedText,
+    CompetingLocator,
+    SourceFileChanged,
+    SectionPathChanged,
+    SourceLineChanged,
+    AtomIndexChanged,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ConfidenceBasis {
+    Exact,
+    Candidate,
+    Unresolved,
+    Unmatched,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ApprovalStatus {
+    NotRequired,
+    NotApproved,
+}
+
+/// A top-level, mutually exclusive migration outcome.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationEntry {
+    pub classification: Classification,
+    pub evidence: Vec<EvidenceCode>,
+    pub confidence_basis: ConfidenceBasis,
+    pub approval_status: ApprovalStatus,
+    pub old: Vec<InventoryRequirement>,
+    pub new: Vec<InventoryRequirement>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationSummary {
+    pub total_old: usize,
+    pub total_new: usize,
+    /// Counts of top-level report entries. Grouped outcomes count once here.
+    pub unchanged: usize,
+    pub observed_id_changes: usize,
+    pub substantive_change_candidates: usize,
+    pub atomization_change_candidates: usize,
+    pub ambiguity_groups: usize,
+    pub retired: usize,
+    pub added: usize,
+    /// Old-side requirement counts by outcome; these sum to `total_old`.
+    pub old_requirements: MigrationOutcomeCounts,
+    /// New-side requirement counts by outcome; these sum to `total_new`.
+    pub new_requirements: MigrationOutcomeCounts,
+}
+
+/// Number of requirements assigned to each outcome on one side of a migration.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+pub struct MigrationOutcomeCounts {
+    pub unchanged: usize,
+    pub observed_id_changes: usize,
+    pub substantive_change_candidates: usize,
+    pub atomization_change_candidates: usize,
+    pub ambiguous: usize,
+    pub retired: usize,
+    pub added: usize,
+}
+
+impl MigrationOutcomeCounts {
+    #[must_use]
+    pub const fn total(&self) -> usize {
+        self.unchanged
+            + self.observed_id_changes
+            + self.substantive_change_candidates
+            + self.atomization_change_candidates
+            + self.ambiguous
+            + self.retired
+            + self.added
+    }
+}
+
+/// Complete deterministic policy migration analysis.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct MigrationReport {
+    pub schema_version: &'static str,
+    pub forge_version: &'static str,
+    pub analysis_complete: bool,
+    pub old_source: SourceProvenance,
+    pub new_source: SourceProvenance,
+    pub summary: MigrationSummary,
+    pub entries: Vec<MigrationEntry>,
+}
+
+impl MigrationReport {
+    #[must_use]
+    pub fn has_reviewable_changes(&self) -> bool {
+        self.entries.iter().any(|entry| {
+            entry.classification != Classification::Unchanged
+                || entry.evidence.iter().any(|evidence| {
+                    matches!(
+                        evidence,
+                        EvidenceCode::SourceFileChanged
+                            | EvidenceCode::SectionPathChanged
+                            | EvidenceCode::SourceLineChanged
+                            | EvidenceCode::AtomIndexChanged
+                    )
+                })
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct RequirementInventory {
+    pub source: SourceProvenance,
+    pub requirements: Vec<InventoryRequirement>,
+}

--- a/tests/migration_cli_test.rs
+++ b/tests/migration_cli_test.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+
+use serde_json::Value;
+
+fn forge() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_forge"))
+}
+
+#[test]
+fn identical_policy_emits_complete_json_and_exits_zero() {
+    let fixture = "tests/fixtures/sample_policy.md";
+    let output = forge().args(["migrate", fixture, fixture, "--format", "json"]).output().unwrap();
+
+    assert!(output.status.success(), "stderr: {}", String::from_utf8_lossy(&output.stderr));
+    assert!(output.stderr.is_empty());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["schema_version"], "forge.migration-report/1");
+    assert_eq!(report["forge_version"], env!("CARGO_PKG_VERSION"));
+    assert_eq!(report["analysis_complete"], true);
+    assert_eq!(report["summary"]["total_old"], report["summary"]["total_new"]);
+    assert_eq!(report["summary"]["old_requirements"]["unchanged"], report["summary"]["total_old"]);
+    assert_eq!(report["summary"]["new_requirements"]["unchanged"], report["summary"]["total_new"]);
+
+    let repeated =
+        forge().args(["migrate", fixture, fixture, "--format", "json"]).output().unwrap();
+    assert_eq!(output.stdout, repeated.stdout, "identical inputs must be byte-deterministic");
+}
+
+#[test]
+fn substantive_change_report_is_written_before_exit_one() {
+    let old = "tests/fixtures/edge-cases/ec06-substantive-change/input-original.md";
+    let new = "tests/fixtures/edge-cases/ec06-substantive-change/input-changed.md";
+    let output = forge().args(["migrate", old, new, "--format", "json"]).output().unwrap();
+
+    assert_eq!(output.status.code(), Some(1));
+    assert!(output.stderr.is_empty());
+    let report: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(report["summary"]["substantive_change_candidates"], 1);
+}
+
+#[test]
+fn analysis_failure_exits_two_without_partial_report() {
+    let output = forge()
+        .args(["migrate", "missing-old.md", "missing-new.md", "--format", "json"])
+        .output()
+        .unwrap();
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(output.stdout.is_empty());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("Migration analysis error"));
+}


### PR DESCRIPTION
## Summary

- add the read-only forge migrate OLD_POLICY NEW_POLICY command using the shared policy preparation and stable-ID pipeline
- classify exact, relocated, edited, ambiguous, retired, and added requirements with deterministic text and versioned JSON reports
- enforce report reconciliation, safe output handling, and the documented 0/1/2 CI exit contract

## Scope

This delivers PRD 53 Phase 1. Successor-map declarations and atomization split/merge lineage remain in the planned Phase 2.

## Validation

- cargo test --all-features: 1,590 passed, 3 ignored
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --check
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a migration command to compare two policy revisions by stable IDs.
  - Reports identify unchanged, edited, moved, added, retired, and ambiguous requirements.
  - Supports human-readable text or JSON output, including optional report files.
  - Added configurable input-size limits and deterministic report generation.

- **Bug Fixes**
  - Prevented report files from overwriting either input policy.
  - Added clear exit codes for detected changes and migration errors.

- **Tests**
  - Added coverage for identical policies, changes, failures, deterministic JSON, and unsafe output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->