### PR TITLE
chore(deps): clean dependency maintenance backlog

### DIFF
--- a/deny.toml
+++ b/deny.toml
@@ -15,7 +15,6 @@ allow = [
     "BSD-3-Clause",
     "Zlib",
     "Unicode-3.0",
-    "Zlib",
 ]
 confidence-threshold = 0.8
 


### PR DESCRIPTION
## Summary

- remove the duplicate Zlib license allowance that caused a false cargo-deny warning
- retain the currently vetted Cargo.lock dependency set
- close stale Dependabot PRs #102, #103, #104, #105, #113, and #114 because merged main already meets or exceeds every requested version

## Supply-chain decision

A full compatible cargo update would change 95 packages and require 95 new cargo-vet exemptions. That broader trust-policy expansion is intentionally not included in this maintenance PR. GitHub currently reports zero open Dependabot security alerts.

## Validation

- cargo test --all-features: 1593 passed, 3 ignored
- cargo clippy --all-targets --all-features -- -D warnings
- cargo fmt --all -- --check
- cargo audit: no vulnerabilities; one explicitly allowed unmaintained warning for ttf-parser
- cargo deny check: advisories, bans, licenses, and sources pass
- cargo vet --locked: succeeded with 283 existing exemptions
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated license compliance settings by removing Zlib from the allowed license list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->